### PR TITLE
Adicionando informação sobre contribuições

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Atenção:** Este projeto é mantido no [repositório comunitário](https://softwarepublico.gov.br/gitlab/i-educar/i-educar/), favor publicar suas contribuições através [deste repositório](https://softwarepublico.gov.br/gitlab/i-educar/i-educar/).
+
 # i-Educar
 
 _“Lançando o maior software livre educacional do Brasil!”._


### PR DESCRIPTION
Contexto: Das 4 issues atualmente abertas neste projeto, 3 possuem a mesma resposta: favor mover a discussão para o Slack ou repositório da comunidade.

Proposta: adicionar um aviso e back-link para que contribuintes possam ao menos se guiar.