### PR TITLE
Novas análises na exportação para o Educacenso / Conversão de campos no arquivo final do Educacenso / Revisão da classe Portabilis_Utils_Validation

### DIFF
--- a/ieducar/lib/Portabilis/Utils/Validation.php
+++ b/ieducar/lib/Portabilis/Utils/Validation.php
@@ -95,4 +95,95 @@ class Portabilis_Utils_Validation {
 
     return ($primeiroDigito == $cpf[9] && $segundoDigito == $cpf[10]);
   }
+
+  /**
+   * Valida os novos formatos de Certidão Civil.
+   *
+   * @author Thieres Tembra <tdt@mytdt.com.br>
+   *
+   * @param  string  $certidao Certidão a ser validada.
+   * @param  bool  $motivo optional Se deseja retornar o motivo em string.
+   * @return bool|string Se !$motivo retorna true/false.
+   *                     Se $motivo retorna uma string com o motivo da falha ou uma string vazia (sucesso).
+   */
+  public static function validatesCertidaoNovoFormato($certidao, $motivo = false) {
+    // invalida se não tiver 32 caracteres
+    if (strlen($certidao) !== 32) {
+        if ($motivo) {
+            return 'Tamanho inválido';
+        }
+        return false;
+    }
+
+    // converte para maiúsculas
+    $certidao = mb_strtoupper($certidao);
+
+    // obtém primeiros 30 dígitos
+    $numeros = substr($certidao, 0, 30);
+
+    // obtém 1º e 2º digito verificador
+    $primeiroDigito = substr($certidao, 30, 1);
+    $segundoDigito = substr($certidao, 31, 1);
+
+    /**
+     * se após retirar todos os dígitos dos primeiros 30 caracteres ainda sobrar alguma coisa
+     * ou se após retirar todos os dígitos e caractere X dos 1º e 2º dígito, ainda sobrar alguma coisa
+     * invalida, pois existem caracteres inválidos (aceita somente dígitos e X nos últimos 2 caracteres)
+     */
+    if (strlen(preg_replace('/\d/', '', $numeros)) !== 0
+        || strlen(preg_replace('/\d|X/', '', $primeiroDigito . $segundoDigito)) !== 0) {
+        if ($motivo) {
+            return 'Caractere(s) inválido(s)';
+        }
+        return false;
+    }
+
+    // define iterações que irá realizar
+    $iteracoes = [
+        [
+            'numeros' => $numeros,
+            'digito' => $primeiroDigito,
+        ],
+        [
+            'numeros' => $numeros . $primeiroDigito,
+            'digito' => $segundoDigito,
+        ],
+    ];
+
+    foreach ($iteracoes as $iteracao) {
+        // reseta a soma
+        $soma = 0;
+
+        // define multiplicador inicial
+        $multiplicador = 9;
+
+        // calcula módulo 11
+        for ($i = strlen($iteracao['numeros']) - 1; $i >= 0; $i--) {
+            $soma += $iteracao['numeros'][$i] * $multiplicador--;
+            if ($multiplicador === -1) {
+                $multiplicador = 10;
+            }
+        }
+        $mod = $soma % 11;
+
+        /**
+         * invalida nos seguintes casos:
+         *   - se o módulo 11 não for 10 e o dígito for diferente do valor do módulo 11
+         *   - se o módulo 11 for 10 e o dígito não for 1 ou X
+         */
+        if (($mod !== 10 && intval($iteracao['digito']) !== $mod)
+            || ($mod === 10 && !in_array($iteracao['digito'], ['1', 'X']) )) {
+            if ($motivo) {
+                return 'Valor inválido';
+            }
+            return false;
+        }
+    }
+
+    // se passou por tudo finalmente retorna sucesso
+    if ($motivo) {
+        return '';
+    }
+    return true;
+  }
 }

--- a/ieducar/lib/Portabilis/Utils/Validation.php
+++ b/ieducar/lib/Portabilis/Utils/Validation.php
@@ -1,189 +1,260 @@
 <?php
 
-#error_reporting(E_ALL);
-#ini_set("display_errors", 1);
-
-/**
- * i-Educar - Sistema de gestão escolar
- *
- * Copyright (C) 2006  Prefeitura Municipal de Itajaí
- *                     <ctima@itajai.sc.gov.br>
- *
- * Este programa é software livre; você pode redistribuí-lo e/ou modificá-lo
- * sob os termos da Licença Pública Geral GNU conforme publicada pela Free
- * Software Foundation; tanto a versão 2 da Licença, como (a seu critério)
- * qualquer versão posterior.
- *
- * Este programa é distribuí­do na expectativa de que seja útil, porém, SEM
- * NENHUMA GARANTIA; nem mesmo a garantia implí­cita de COMERCIABILIDADE OU
- * ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral
- * do GNU para mais detalhes.
- *
- * Você deve ter recebido uma cópia da Licença Pública Geral do GNU junto
- * com este programa; se não, escreva para a Free Software Foundation, Inc., no
- * endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.
- *
- * @author    Lucas D'Avila <lucasdavila@portabilis.com.br>
- * @category  i-Educar
- * @license   @@license@@
- * @package   Portabilis
- * @since     Arquivo disponível desde a versão 1.1.0
- * @version   $Id$
- */
-
-require_once 'lib/Portabilis/Utils/User.php';
-
-/**
- * Portabilis_Utils_Validation class.
- *
- * @author    Lucas D'Avila <lucasdavila@portabilis.com.br>
- * @category  i-Educar
- * @license   @@license@@
- * @package   Portabilis
- * @since     Classe disponível desde a versão 1.1.0
- * @version   @@package_version@@
- */
-class Portabilis_Utils_Validation {
-
-  public static function validatesCpf($cpf) {
-    $cpf = preg_replace('/[^0-9]/', '', (string)$cpf);
-
-    if (strlen($cpf) != 11)
-      return false;
-
-    $cpfsInvalidos = array(
-      '00000000000',
-      '11111111111',
-      '22222222222',
-      '33333333333',
-      '44444444444',
-      '55555555555',
-      '66666666666',
-      '77777777777',
-      '88888888888',
-      '99999999999'
-    );
-
-    if (in_array($cpf, $cpfsInvalidos)) {
-      return false;
-    }
-
-    // calcula primeiro dígito verificador
-    $soma = 0;
-
-    for ($i = 0; $i < 9; $i++)
-      $soma += ((10 - $i) * $cpf[$i]);
-
-    $primeiroDigito = 11 - ($soma % 11);
-
-    if ($primeiroDigito >= 10)
-      $primeiroDigito = 0;
-
-
-    // calcula segundo dígito verificador
-    $soma = 0;
-
-    for ($i = 0; $i < 10; $i++)
-      $soma += ((11 - $i) * $cpf[$i]);
-
-    $segundoDigito = 11 - ($soma % 11);
-
-    if ($segundoDigito >= 10)
-      $segundoDigito = 0;
-
-
-
-    return ($primeiroDigito == $cpf[9] && $segundoDigito == $cpf[10]);
-  }
-
-  /**
-   * Valida os novos formatos de Certidão Civil.
-   *
-   * @author Thieres Tembra <tdt@mytdt.com.br>
-   *
-   * @param  string  $certidao Certidão a ser validada.
-   * @param  bool  $motivo optional Se deseja retornar o motivo em string.
-   * @return bool|string Se !$motivo retorna true/false.
-   *                     Se $motivo retorna uma string com o motivo da falha ou uma string vazia (sucesso).
-   */
-  public static function validatesCertidaoNovoFormato($certidao, $motivo = false) {
-    // invalida se não tiver 32 caracteres
-    if (strlen($certidao) !== 32) {
-        if ($motivo) {
-            return 'Tamanho inválido';
-        }
-        return false;
-    }
-
-    // converte para maiúsculas
-    $certidao = mb_strtoupper($certidao);
-
-    // obtém primeiros 30 dígitos
-    $numeros = substr($certidao, 0, 30);
-
-    // obtém 1º e 2º digito verificador
-    $primeiroDigito = substr($certidao, 30, 1);
-    $segundoDigito = substr($certidao, 31, 1);
-
+class Portabilis_Utils_Validation
+{
     /**
-     * se após retirar todos os dígitos dos primeiros 30 caracteres ainda sobrar alguma coisa
-     * ou se após retirar todos os dígitos e caractere X dos 1º e 2º dígito, ainda sobrar alguma coisa
-     * invalida, pois existem caracteres inválidos (aceita somente dígitos e X nos últimos 2 caracteres)
-     */
-    if (strlen(preg_replace('/\d/', '', $numeros)) !== 0
-        || strlen(preg_replace('/\d|X/', '', $primeiroDigito . $segundoDigito)) !== 0) {
-        if ($motivo) {
-            return 'Caractere(s) inválido(s)';
-        }
-        return false;
-    }
+    * Valida um CPF.
+    *
+    * @author Lucas D'Avila <lucasdavila@portabilis.com.br>
+    * @author Thieres Tembra <tdt@mytdt.com.br>
+    *
+    * @param  string  $cpf CPF a ser validado.
+    *
+    * @return bool
+    */
+    public static function validatesCpf($cpf)
+    {
+        // converte o CPF para string e remove todos os caracteres que não números
+        $cpf = preg_replace('/[^0-9]/', '', (string) $cpf);
 
-    // define iterações que irá realizar
-    $iteracoes = [
-        [
-            'numeros' => $numeros,
-            'digito' => $primeiroDigito,
-        ],
-        [
-            'numeros' => $numeros . $primeiroDigito,
-            'digito' => $segundoDigito,
-        ],
-    ];
-
-    foreach ($iteracoes as $iteracao) {
-        // reseta a soma
-        $soma = 0;
-
-        // define multiplicador inicial
-        $multiplicador = 9;
-
-        // calcula módulo 11
-        for ($i = strlen($iteracao['numeros']) - 1; $i >= 0; $i--) {
-            $soma += $iteracao['numeros'][$i] * $multiplicador--;
-            if ($multiplicador === -1) {
-                $multiplicador = 10;
-            }
-        }
-        $mod = $soma % 11;
-
-        /**
-         * invalida nos seguintes casos:
-         *   - se o módulo 11 não for 10 e o dígito for diferente do valor do módulo 11
-         *   - se o módulo 11 for 10 e o dígito não for 1 ou X
-         */
-        if (($mod !== 10 && intval($iteracao['digito']) !== $mod)
-            || ($mod === 10 && !in_array($iteracao['digito'], ['1', 'X']) )) {
-            if ($motivo) {
-                return 'Valor inválido';
-            }
+        // invalida se não tiver 11 caracteres
+        if (mb_strlen($cpf) !== 11) {
             return false;
         }
+
+        $cpfsInvalidos = [
+            '00000000000',
+            '11111111111',
+            '22222222222',
+            '33333333333',
+            '44444444444',
+            '55555555555',
+            '66666666666',
+            '77777777777',
+            '88888888888',
+            '99999999999',
+        ];
+
+        // verifica se o CPF informado está entre os inválidos
+        if (in_array($cpf, $cpfsInvalidos)) {
+            return false;
+        }
+
+        // verifica se o módulo 11 bate com o primeiro dígito
+        if (!self::isValidMod11Digit(substr($cpf, 0, 9), $cpf[9], '0')) {
+            return false;
+        }
+
+        // verifica se o módulo 11 bate com o segundo dígito
+        if (!self::isValidMod11Digit(substr($cpf, 0, 10), $cpf[10], '0')) {
+            return false;
+        }
+
+        // finalmente valida o CPF
+        return true;
     }
 
-    // se passou por tudo finalmente retorna sucesso
-    if ($motivo) {
-        return '';
+    /**
+    * Valida os novos formatos de Certidão Civil.
+    *
+    * @author Thieres Tembra <tdt@mytdt.com.br>
+    *
+    * @param  string  $certidao Certidão a ser validada.
+    * @param  bool  $throwException optional Se deseja lançar uma exceção caso a certidão seja inválida.
+    *
+    * @throws \Exception Se $certidao for inválida e $throwException for true.
+    *
+    * @return bool
+    */
+    public static function validatesCertidaoNovoFormato($certidao, $throwException = false)
+    {
+        // invalida se não tiver 32 caracteres
+        if (mb_strlen($certidao) !== 32) {
+            if ($throwException) {
+                throw new \Exception('Tamanho inválido');
+            }
+
+            return false;
+        }
+
+        // converte para maiúsculas
+        $certidao = mb_strtoupper($certidao);
+
+        // obtém primeiros 30 dígitos
+        $numeros = mb_substr($certidao, 0, 30);
+
+        // obtém 1º e 2º digito verificador
+        $primeiroDigito = mb_substr($certidao, 30, 1);
+        $segundoDigito = mb_substr($certidao, 31, 1);
+
+        // verifica se contém apenas caracteres válidos
+        if (!self::hasOnlyValidChars($numeros, '/\d/')
+            || !self::hasOnlyValidChars($primeiroDigito . $segundoDigito, '/\d|X/')) {
+            if ($throwException) {
+                throw new \Exception('Caractere(s) inválido(s)');
+            }
+
+            return false;
+        }
+
+        /*
+         * verifica se o módulo 11 não foi calculado e portanto informado como XX conforme publicação do CNJ no
+         * Diário da Justiça - Edição nº 198/2009 (Página 18) - Provimento nº 3, Artigo 7º, Inciso IX, Parágrafo 2º
+         *
+         * neste caso a certidão deve ser validada
+         */
+        if ($primeiroDigito . $segundoDigito === 'XX') {
+            return true;
+        }
+
+        // verifica se o módulo 11 bate com o primeiro dígito
+        if (!self::isValidMod11Digit($numeros, $primeiroDigito, '1')) {
+            if ($throwException) {
+                throw new \Exception('Valor inválido');
+            }
+
+            return false;
+        }
+
+        // verifica se o módulo 11 bate com o segundo dígito
+        if (!self::isValidMod11Digit($numeros . $primeiroDigito, $segundoDigito, '1')) {
+            if ($throwException) {
+                throw new \Exception('Valor inválido');
+            }
+
+            return false;
+        }
+
+        // finalmente valida a certidão civil
+        return true;
     }
-    return true;
-  }
+
+    /**
+    * Valida o tipo da Certidão Civil (novo formato).
+    *
+    * @author Thieres Tembra <tdt@mytdt.com.br>
+    *
+    * @param  string  $certidao Certidão a ser validada.
+    * @param  string  $tipo Tipo da certidão a ser validada.
+    *
+    * @throws \Exception Se o $tipo fornecido for inválido.
+    *
+    * @return bool
+    */
+    public static function validatesTipoCertidaoNovoFormato($certidao, $tipo)
+    {
+        $tiposValidos = [
+            '1', // Livro A (Nascimento)
+            '2', // Livro B (Casamento)
+            '3', // Livro B Auxiliar (Casamento Religioso com efeito civil)
+            '4', // Livro C (Óbito)
+            '5', // Livro C Auxiliar (Natimorto)
+            '6', // Livro D (Registro de Proclamas)
+            '7', // Livro E (Demais atos relativos ao registro civil ou livro E único)
+            '8', // Livro E (Desdobrado para registro especifico das Emancipações)
+            '9', // Livro E (Desdobrado para registro especifico das Interdições)
+        ];
+
+        if (!in_array($tipo, $tiposValidos)) {
+            throw new \Exception('Tipo inválido');
+        }
+
+        if (substr($certidao, 14, 1) !== $tipo) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+    * Valida o ano da Certidão Civil (novo formato).
+    *
+    * @author Thieres Tembra <tdt@mytdt.com.br>
+    *
+    * @param  string  $certidao Certidão a ser validada.
+    * @param  string  $anoBase optional Ano base de geração da certidão.
+    *
+    * @return bool
+    */
+    public static function validatesAnoCertidaoNovoFormato($certidao, $anoBase = null)
+    {
+        $ano = substr($certidao, 10, 4);
+        $anoAtual = date('Y');
+
+        if (($anoBase !== null && $ano < $anoBase) || $ano > $anoAtual) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+    * Verifica se uma string possui apenas caracteres válidos de acordo com a expressão regular fornecida.
+    *
+    * @author Thieres Tembra <tdt@mytdt.com.br>
+    *
+    * @param  string  $value String que será verificada.
+    * @param  string  $validCharsRegex Expressão regular com os caracteres válidos.
+    *
+    * @return bool
+    */
+    public static function hasOnlyValidChars($value, $validCharsRegex)
+    {
+        if (mb_strlen(preg_replace($validCharsRegex, '', $value)) !== 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+    * Verifica se o dígito informado é o resultado do módulo 11 da string informada.
+    *
+    * @author Thieres Tembra <tdt@mytdt.com.br>
+    *
+    * @param  string  $value String que será calculado o módulo 11.
+    * @param  string  $digit Dígito para verificar se bate com o módulo 11.
+    * @param  string  $result10 String caso o módulo 11 seja 10.
+    *
+    * @return bool
+    */
+    public static function isValidMod11Digit($value, $digit, $result10)
+    {
+        if ($digit !== self::calcMod11($value, $result10)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+    * Calcula o módulo 11 de uma string.
+    *
+    * @author Thieres Tembra <tdt@mytdt.com.br>
+    *
+    * @param  string  $value String que será calculado o módulo 11.
+    * @param  string  $convertResult10 String que será retornada caso o módulo 11 seja 10.
+    *
+    * @return string
+    */
+    public static function calcMod11($value, $convertResult10)
+    {
+        $sum = 0;
+        $mult = 9;
+
+        for ($i = mb_strlen($value) - 1; $i >= 0; $i--) {
+            $sum += $value[$i] * $mult--;
+            if ($mult === -1) {
+                $mult = 10;
+            }
+        }
+
+        $mod = $sum % 11;
+
+        if ($mod === 10) {
+            return $convertResult10;
+        }
+
+        return (string) $mod;
+    }
 }

--- a/ieducar/modules/Api/Views/EducacensoAnaliseController.php
+++ b/ieducar/modules/Api/Views/EducacensoAnaliseController.php
@@ -1408,14 +1408,24 @@ class EducacensoAnaliseController extends ApiCoreController
                               "fail" => true);
         }
       } else if (!$certidaoAntigoFormato && !empty($certidaoAlunoNovoFormato)) {
-        $certidaoNovoFormatoMotivo = mb_strtolower(Portabilis_Utils_Validation::validatesCertidaoNovoFormato($certidaoAlunoNovoFormato, true));
-        if (!empty($certidaoNovoFormatoMotivo)) {
+        try {
+          Portabilis_Utils_Validation::validatesCertidaoNovoFormato($certidaoAlunoNovoFormato, true);
+
+          if (!Portabilis_Utils_Validation::validatesAnoCertidaoNovoFormato($certidaoAlunoNovoFormato, substr($aluno["data_nasc"], 0, 4))) {
+            $mensagem[] = array("text" => "Dados para formular o registro 70 da escola {$nomeEscola} não encontrados. Verificamos que o tipo da certidão civil do(a) aluno(a) {$nomeAluno} foi informado como formato novo, mas a certidão informada possui ano de registro anterior à sua data de nascimento ou posterior à data corrente.",
+                                "path" => "(Pessoas > Cadastros > Pessoas físicas > Cadastrar > Editar > Campo: Tipo certidão civil)",
+                                "linkPath" => "/intranet/atendidos_cad.php?cod_pessoa_fj={$idpesAluno}",
+                                "fail" => true);
+          }
+          if (!Portabilis_Utils_Validation::validatesTipoCertidaoNovoFormato($certidaoAlunoNovoFormato, '1')) {
+            $mensagem[] = array("text" => "Dados para formular o registro 70 da escola {$nomeEscola} não encontrados. Verificamos que o tipo da certidão civil do(a) aluno(a) {$nomeAluno} foi informado como formato novo, mas a certidão informada não é do tipo nascimento.",
+                                "path" => "(Pessoas > Cadastros > Pessoas físicas > Cadastrar > Editar > Campo: Tipo certidão civil)",
+                                "linkPath" => "/intranet/atendidos_cad.php?cod_pessoa_fj={$idpesAluno}",
+                                "fail" => true);
+          }
+        } catch (\Exception $e) {
+          $certidaoNovoFormatoMotivo = mb_strtolower($e->getMessage());
           $mensagem[] = array("text" => "Dados para formular o registro 70 da escola {$nomeEscola} não encontrados. Verificamos que o tipo da certidão civil do(a) aluno(a) {$nomeAluno} foi informado como formato novo, mas a certidão informada possui {$certidaoNovoFormatoMotivo}.",
-                              "path" => "(Pessoas > Cadastros > Pessoas físicas > Cadastrar > Editar > Campo: Tipo certidão civil)",
-                              "linkPath" => "/intranet/atendidos_cad.php?cod_pessoa_fj={$idpesAluno}",
-                              "fail" => true);
-        } else if (substr($certidaoAlunoNovoFormato, 10, 4) < substr($aluno["data_nasc"], 0, 4) || substr($certidaoAlunoNovoFormato, 10, 4) > substr($dataAtual, 0, 4)) {
-          $mensagem[] = array("text" => "Dados para formular o registro 70 da escola {$nomeEscola} não encontrados. Verificamos que o tipo da certidão civil do(a) aluno(a) {$nomeAluno} foi informado como formato novo, mas a certidão informada possui ano de registro anterior à sua data de nascimento ou posterior à data corrente.",
                               "path" => "(Pessoas > Cadastros > Pessoas físicas > Cadastrar > Editar > Campo: Tipo certidão civil)",
                               "linkPath" => "/intranet/atendidos_cad.php?cod_pessoa_fj={$idpesAluno}",
                               "fail" => true);

--- a/ieducar/modules/Api/Views/EducacensoExportController.php
+++ b/ieducar/modules/Api/Views/EducacensoExportController.php
@@ -380,7 +380,7 @@ class EducacensoExportController extends ApiCoreController
         LEFT JOIN public.municipio ON (municipio.idmun = bairro.idmun)
         LEFT JOIN public.uf ON (uf.sigla_uf = COALESCE(municipio.sigla_uf, ee.sigla_uf))
         LEFT JOIN public.distrito ON (distrito.idmun = bairro.idmun)
-    
+
         LEFT JOIN urbano.cep_logradouro_bairro clb ON (clb.idbai = ep.idbai AND clb.idlog = ep.idlog AND clb.cep = ep.cep)
         LEFT JOIN urbano.cep_logradouro cl ON (cl.idlog = clb.idlog AND clb.cep = cl.cep)
         LEFT JOIN public.logradouro l ON (l.idlog = cl.idlog)
@@ -395,7 +395,7 @@ class EducacensoExportController extends ApiCoreController
       $r00s2 = substr($r00s2, 0, 8);
       $r00s3 = $this->cpfToCenso($r00s3);
       $r00s4 = $this->convertStringToCenso($r00s4);
-      $r00s6 = strtoupper($r00s6);
+      $r00s6 = $this->convertEmailToCenso($r00s6);
 
       $r00s8 = Portabilis_Date_Utils::pgSQLToBr($r00s8);
       $r00s9 = Portabilis_Date_Utils::pgSQLToBr($r00s9);
@@ -405,7 +405,7 @@ class EducacensoExportController extends ApiCoreController
       $r00s15 = $this->convertStringToCenso($r00s15);
       $r00s16 = $this->convertStringToCenso($r00s16);
       $r00s17 = $this->convertStringToCenso($r00s17);
-      $r00s26 = strtoupper($r00s26);
+      $r00s26 = $this->convertEmailToCenso($r00s26);
       $r00s27 = ($r00s27 ? str_pad($r00s27, 5, "0", STR_PAD_LEFT) : NULL);
 
       $r00s37 = $this->cnpjToCenso($r00s37);
@@ -887,7 +887,7 @@ class EducacensoExportController extends ApiCoreController
     extract(Portabilis_Utils_Database::fetchPreparedQuery($sql, array('return_only' => 'first-row', 'params' => array($servidorId, $escolaId))));
     if ($r30s1){
       $r30s5 = $this->convertStringToCenso($r30s5);
-      $r30s6 = strtoupper($r30s6);
+      $r30s6 = $this->convertEmailToCenso($r30s6);
       $r30s8 = Portabilis_Date_Utils::pgSQLToBr($r30s8);
       $r30s9 = $r30s9 == 'M' ? 1 : 2;
       $r30s10 = is_numeric($r30s10) ? $r30s10 : 0;
@@ -1077,7 +1077,7 @@ class EducacensoExportController extends ApiCoreController
         (ARRAY[16] <@ curso_formacao_continuada)::INT AS r50s43,
         s.situacao_curso_superior_1,
         s.situacao_curso_superior_2,
-        s.situacao_curso_superior_3 
+        s.situacao_curso_superior_3
         FROM    pmieducar.servidor s
         INNER JOIN cadastro.fisica fis ON (fis.idpes = s.cod_servidor)
         INNER JOIN cadastro.pessoa p ON (fis.idpes = p.idpes)
@@ -1719,6 +1719,10 @@ protected function exportaDadosRegistro70($escolaId, $ano, $data_ini, $data_fim,
       extract($reg);
 
       $r70s8 = Portabilis_Date_Utils::pgSQLToBr($r70s8);
+
+      // deixa apenas dígitos no livro da certidão civil (formato antigo) - sistema do Educacenso está recusando outros caracteres
+      $r70s13 = preg_replace('/\D/', '', $r70s13);
+
       $r70s14 = Portabilis_Date_Utils::pgSQLToBr($r70s14);
 
       $r70s18 = $this->convertStringToCertNovoFormato($r70s18);


### PR DESCRIPTION
### **Primeiro commit**

Adicionadas novas análises na exportação para o Educacenso:

**Registro 60**

- Verificado se o INEP do aluno possui 12 dígitos.

**Registro 70**

- Verificado se a data de emissão da identidade foi informado, quando o número da identidade é informado.

- Verificado se a data de emissão da identidade é maior que a data de nascimento do aluno e menor que a data corrente, quando o número da identidade é informado.

- Verificado se o campo livro da certidão civil contém apenas dígitos quando o tipo da certidão é formato antigo. Exibido apenas aviso.

- Verificado se a data de emissão da certidão civil foi informado, quando o tipo da certidão é formato antigo.

- Verificado se a data de emissão da certidão civil é maior que a data de nascimento do aluno e menor que a data corrente, quando o tipo da certidão é formato antigo.

- Verificado validação da certidão civil, quando novo formato, retornando o motivo da não validação (tamanho inválido, caractere(s) inválido(s), valor inválido).

- Verificado se o ano da certidão civil é igual ou maior que o ano de nascimento e menor ou igual ao ano corrente, quando novo formato.

- Verificado se o NIS (PIS/PASEP) do aluno possui 11 dígitos.

---

### **Segundo commit**

Foram feitas conversões de alguns campos antes de gerar o arquivo final para o Educacenso:

**Registro 00**

- Campo 6: E-mail do gestor escolar

- Campo 26: E-mail da escola

**Registro 30**

- Campo 6: E-mail do profissional escolar

**Registro 70**

- Campo 13: Livro da Certidão Civil (antigo formato). O sistema do Educacenso está permitindo apenas dígitos, portanto todos os caracteres que não são dígitos são removidos.

---

### Terceiro commit

As seguintes modificações foram feitas:

- Criado método para verificar a existência apenas de caracteres válidos.
- Criado método para calcular o módulo 11 de uma string.
- Criado método para verificar se o módulo 11 de uma string é igual ao dígito informado.
- Criado método para validar o ano da certidão civil (novo formato).
- Criado método para validar o tipo da certidão civil (novo formato).
- Refatorado o método `validatesCpf` para utilizar o novo método criado.
- Refatorado o método `validatesCertidaoNovoFormato` para utilizar os novos métodos criados, lançar exceções em caso de falhas e dar a tratativa correta para os dígitos verificadores `XX`.
- O arquivo `ieducar/lib/Portabilis/Utils/Validation.php` agora está de acordo com o PSR-2.
- Modificado o uso do método `validatesCertidaoNovoFormato`.
- A validação do ano da certidão agora usa o novo método.
- Verificado o tipo da certidão do aluno.