### PR TITLE
Implementa configuração com lib phpdotenv

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,13 @@
   "homepage": "https://github.com/portabilis/i-educar",
   "require": {
     "php": "~7.0",
+    "cocur/slugify": "^3.1",
+    "gilbitron/php-simplecache": "^1.4",
+    "google/recaptcha": "~1.1",
     "portabilis/jasperphp": "v1.2.0",
     "robmorgan/phinx": "v0.8.1",
-    "gilbitron/php-simplecache": "^1.4",
     "swiftmailer/swiftmailer": "^6.0",
-    "cocur/slugify": "^3.1",
-    "google/recaptcha": "~1.1"
+    "vlucas/phpdotenv": "^2.5"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c7da08454d494dfd06f628aa1453771",
+    "content-hash": "43f449f9579fdc8b79979d7e4b1f7ec1",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -889,6 +889,56 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2018-05-03T23:18:14+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "6ae3e2e6494bb5e58c2decadafc3de7f1453f70a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/6ae3e2e6494bb5e58c2decadafc3de7f1453f70a",
+                "reference": "6ae3e2e6494bb5e58c2decadafc3de7f1453f70a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "http://www.vancelucas.com"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "time": "2018-07-01T10:25:50+00:00"
         }
     ],
     "packages-dev": [

--- a/ieducar/intranet/clsConfigItajai.inc.php
+++ b/ieducar/intranet/clsConfigItajai.inc.php
@@ -88,7 +88,7 @@ class clsConfig
     $this->_instituicao = $config->template->vars->instituicao . ' - ';
 
     // E-mails dos administradores para envio de relatórios de performance
-    $emails = $config->admin->reports->emails->toArray();
+    $emails = explode(',', $config->admin->reports->emails);
     $this->arrayConfig['ArrStrEmailsAdministradores'] = $emails;
 
     // Diretório dos templates de e-mail

--- a/ieducar/intranet/include/clsBase.inc.php
+++ b/ieducar/intranet/include/clsBase.inc.php
@@ -138,7 +138,7 @@ class clsBase extends clsConfig
     {
 
         $saida = $this->OpenTpl('htmlhead');
-        $saida = str_replace("<!-- #&CORE_EXT_CONFIGURATION_ENV&# -->", CORE_EXT_CONFIGURATION_ENV, $saida);
+        $saida = str_replace("<!-- #&CORE_EXT_CONFIGURATION_ENV&# -->", getenv('ambiente'), $saida);
         $saida = str_replace("<!-- #&USER_ID&# -->", $_SESSION['id_pessoa'], $saida);
         $saida = str_replace("<!-- #&TITULO&# -->", $this->titulo, $saida);
 

--- a/ieducar/intranet/include/clsControlador.inc.php
+++ b/ieducar/intranet/include/clsControlador.inc.php
@@ -241,7 +241,7 @@ class clsControlador
         $templateText = str_replace( "<!-- #&RECAPTCHA&# -->", Portabilis_Utils_ReCaptcha::getWidget(), $templateText);
     }
 
-    $templateText = str_replace("<!-- #&CORE_EXT_CONFIGURATION_ENV&# -->", CORE_EXT_CONFIGURATION_ENV, $templateText);
+    $templateText = str_replace("<!-- #&CORE_EXT_CONFIGURATION_ENV&# -->", getenv('ambiente'), $templateText);
     $templateText = str_replace("<!-- #&BRASAO&# -->", $this->getLoginLogo($configuracoes), $templateText);
     $templateText = str_replace("<!-- #&NOME_ENTIDADE&# -->", $configuracoes["ieducar_entity_name"], $templateText);
     $templateText = str_replace("<!-- #&RODAPE_LOGIN&# -->", $configuracoes["ieducar_login_footer"], $templateText);

--- a/ieducar/lib/CoreExt/Config/Env.php
+++ b/ieducar/lib/CoreExt/Config/Env.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace iEducar\Config;
+
+use CoreExt_Config;
+use Dotenv\Dotenv;
+
+class Env extends CoreExt_Config
+{
+    /**
+     * Env constructor.
+     * @param Dotenv $enviroment
+     * @param Dotenv[] $tenants
+     */
+    public function __construct(Dotenv $enviroment, $tenants = [])
+    {
+        $enviroment->load();
+
+        $this->loadTenants($tenants);
+
+        parent::__construct($this->getEnviromentVariables());
+    }
+
+    /**
+     * @param Dotenv $file
+     */
+    public function addFile(Dotenv $file): void
+    {
+        $file->overload();
+    }
+
+    /**
+     * @param Dotenv[] $tenants
+     */
+    private function loadTenants($tenants)
+    {
+        foreach ($tenants as $tenant) {
+            $tenant->overload();
+        }
+    }
+
+    /**
+     * @return array
+     */
+    private function getEnviromentVariables(): array
+    {
+        $config = [];
+        $entries = $_ENV;
+
+        foreach ($entries as $key => $value) {
+            if (strpos($key, '.') !== false) {
+                $keys = explode('.', $key);
+            } else {
+                $keys = (array)$key;
+            }
+
+            $config = $this->processDirectives($value, $keys, $config);
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param $value
+     * @param $keys
+     * @param array $config
+     * @return array
+     */
+    private function processDirectives($value, $keys, $config = [])
+    {
+        $key = array_shift($keys);
+
+        if (count($keys) == 0) {
+            $config[$key] = $value;
+
+            return $config;
+        }
+
+        if (!array_key_exists($key, $config)) {
+            $config[$key] = array();
+        }
+
+        $config[$key] = $this->processDirectives($value, $keys, $config[$key]);
+        return $config;
+    }
+}

--- a/ieducar/lib/Portabilis/Controller/ReportCoreController.php
+++ b/ieducar/lib/Portabilis/Controller/ReportCoreController.php
@@ -85,9 +85,9 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
 
       $this->beforeValidation();
 
-      if (CORE_EXT_CONFIGURATION_ENV == "production") {
+      if (getenv('ambiente') == "production") {
         $this->report->addArg('SUBREPORT_DIR', "/sites_media_root/services/reports/jasper/");
-      } else if (CORE_EXT_CONFIGURATION_ENV == "development") {
+      } else if (getenv('ambiente') == "development") {
         $this->report->addArg('SUBREPORT_DIR', "modules/Reports/ReportSources/Portabilis/");
       } else {
         $this->report->addArg('SUBREPORT_DIR', "/sites_media_root/services-test/reports/jasper/");

--- a/ieducar/lib/Portabilis/Mailer.php
+++ b/ieducar/lib/Portabilis/Mailer.php
@@ -55,7 +55,7 @@ class Portabilis_Mailer {
                 ->setBody($message, $options['mime']);
 
             $allowedDomains = !empty($this->configs->allowed_domains)
-                ? $this->configs->allowed_domains
+                ? explode(',', $this->configs->allowed_domains)
                 : ['*'];
 
             $result = false;

--- a/ieducar/modules/Api/Views/ReportController.php
+++ b/ieducar/modules/Api/Views/ReportController.php
@@ -97,7 +97,7 @@ class ReportController extends ApiCoreController
       $boletimReport->addArg('turma',       (int)$dadosMatricula['turma_id']);
       $boletimReport->addArg('situacao_matricula', 10);
 
-      if (CORE_EXT_CONFIGURATION_ENV == "production") {
+      if (getenv('ambiente') == "production") {
         $boletimReport->addArg('SUBREPORT_DIR', "/sites_media_root/services/reports/jasper/");
       } else if ($GLOBALS['coreExt']['Config']->app->database->dbname == 'test' || $GLOBALS['coreExt']['Config']->app->database->dbname == 'desenvolvimento') {
         $boletimReport->addArg('SUBREPORT_DIR', "/sites_media_root/services-test/reports/jasper/");
@@ -139,7 +139,7 @@ class ReportController extends ApiCoreController
       $boletimProfessorReport->addArg('modelo', $modelo);
       $boletimProfessorReport->addArg('linha', 0);
 
-      if (CORE_EXT_CONFIGURATION_ENV == "production") {
+      if (getenv('ambiente') == "production") {
         $boletimProfessorReport->addArg('SUBREPORT_DIR', "/sites_media_root/services/reports/jasper/");
       } else if ($GLOBALS['coreExt']['Config']->app->database->dbname == 'test' || $GLOBALS['coreExt']['Config']->app->database->dbname == 'desenvolvimento') {
         $boletimProfessorReport->addArg('SUBREPORT_DIR', "/sites_media_root/services-test/reports/jasper/");


### PR DESCRIPTION
Com o objetivo de facilitar o gerenciamento e manutenção das configurações do i-Educar, tentei fazer uso da biblioteca [phpdotenv](https://github.com/vlucas/phpdotenv), trazendo uma maneira mais simples e moderna para isso. 

É claro que foi implementado de maneira simples, aproveitando as classes e estruturas já existentes no sistema. O ideal no futuro é remover as classes legadas de configurações e substituir todos os usos por algo mais simples como `getenv()`

- Adiciona lib phpdotenv para gerenciar os arquivos de configuração
- Cria classe extendendo classe legada de configuração para pegar as variáveis que foram carregadas pela dotenv

