### PR TITLE
Adicionado composer ao docker-composer.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ um pacote de mais de 40 relatórios funcionais.
 
 O i-Educar usa o [Composer](https://getcomposer.org/) para gerenciar suas
 dependências. O Composer já é executado automaticamente para quem utilizar
-docker-compose, basta dar o `docker-compose up`.
+docker-compose, basta executar o comando `docker-compose up`.
 
 Caso queira adicionar novas dependências ao projeto ou rodar algum outro
-compando do composer, execute da seguinte forma na raiz do projeto:
+comando do composer, execute da seguinte forma na raiz do projeto:
 
 ```bash
 docker run -it -v $(pwd):/app composer <seu_comando_aqui>

--- a/README.md
+++ b/README.md
@@ -120,11 +120,14 @@ um pacote de mais de 40 relatórios funcionais.
 ### Instalando outras dependências
 
 O i-Educar usa o [Composer](https://getcomposer.org/) para gerenciar suas
-dependências. O Composer já vem pré-instalado na imagem via Docker então para
-instalar as dependências use os seguintes comandos:
+dependências. O Composer já é executado automaticamente para quem utilizar
+docker-compose, basta dar o `docker-compose up`.
 
-```terminal
-$ docker-compose exec ieducar_1604 composer install
+Caso queira adicionar novas dependências ao projeto ou rodar algum outro
+compando do composer, execute da seguinte forma na raiz do projeto:
+
+```bash
+docker run -it -v $(pwd):/app composer <seu_comando_aqui>
 ```
 
 ### Inicializando o banco de dados

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,11 @@ services:
     links:
       - postgres_95
     container_name: ieducar_1604
-
+  composer:
+    image: "composer"
+    volumes:
+      - ./:/app
+    command: install
   postgres_95:
     volumes:
       - /var/lib/postgresql/data

--- a/docker/ieducar_1604/Dockerfile
+++ b/docker/ieducar_1604/Dockerfile
@@ -40,12 +40,6 @@ RUN echo "xdebug.remote_enable=\${XDEBUG_REMOTE_ENABLE}" >> /etc/php/7.0/apache2
     && echo "xdebug.remote_port=\${XDEBUG_REMOTE_PORT}" >> /etc/php/7.0/apache2/conf.d/20-xdebug.ini \
     && echo "xdebug.idekey=\${XDEBUG_IDEKEY}" >> /etc/php/7.0/apache2/conf.d/20-xdebug.ini
 
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-    && php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-    && php composer-setup.php \
-    && php -r "unlink('composer-setup.php');" \
-    && mv composer.phar /usr/local/bin/composer
-
 EXPOSE 80
 
 RUN mkdir -p /home/portabilis/ieducar \


### PR DESCRIPTION
Para remover dependência de ter de instalar o composer para depois instalar as dependências do projeto, foi adicionado ao docker-compose.yml a imagem oficia do composer