### PR TITLE
Atualiza readme com passos necessários para iniciar o desenvolvimento

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,15 @@ o Docker Compose para criar os containers da aplicação:
 $ git clone https://github.com/portabilis/i-educar.git i-educar
 $ cd i-educar
 $ cp .env.example .env
+$ cp ieducar/configuration/ieducar.ini.sample ieducar/configuration/ieducar.ini
+$ cp phinx.php.sample phinx.php
 $ docker-compose up -d
 ```
 
-Depois disto faça uma cópia do arquivo `ieducar/configuration/ieducar.ini.sample`
-para `ieducar/configuration/ieducar.ini` realizando as alterações necessárias.
+Depois disto faça as alterações necessárias nos arquivos de configuração:
+- `.env`
+- `ieducar/configuration/ieducar.ini`
+- `phinx.php`
 
 ### Instalando relatórios
 

--- a/ieducar/configuration/ieducar.ini.sample
+++ b/ieducar/configuration/ieducar.ini.sample
@@ -1,27 +1,3 @@
-; $Id$
-
-;
-; i-Educar - Sistema de gestão escolar
-;
-;  Copyright (C) 2006  Prefeitura Municipal de Itajaí
-;                      <ctima@itajai.sc.gov.br>
-;
-; Este programa é software livre; você pode redistribuí-lo e/ou modificá-lo
-; sob os termos da Licença Pública Geral GNU conforme publicada pela Free
-; Software Foundation; tanto a versão 2 da Licença, como (a seu critério)
-; qualquer versão posterior.
-;
-; Este programa é distribuí­do na expectativa de que seja útil, porém, SEM
-; NENHUMA GARANTIA; nem mesmo a garantia implí­cita de COMERCIABILIDADE OU
-; ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral
-; do GNU para mais detalhes.
-;
-; Você deve ter recebido uma cópia da Licença Pública Geral do GNU junto
-; com este programa; se não, escreva para a Free Software Foundation, Inc., no
-; endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.
-;
-
-
 ;
 ; Arquivo de configuração da aplicação.
 ;
@@ -42,12 +18,6 @@
 ;
 ; Recomenda-se deixar esse arquivo com permissão de leitura apenas para o dono
 ; e ao usuário do Apache (ou do webserver de sua preferência).
-;
-; @author   Eriksen Costa Paixão <eriksen.paixao_bs@cobra.com.br>
-; @license  http://creativecommons.org/licenses/GPL/2.0/legalcode.pt  CC GNU GPL
-; @package  CoreExt
-; @since    Arquivo disponível desde a versão 1.1.0
-; @version  $Id$
 ;
 
 [production]
@@ -195,15 +165,14 @@ apis.secret_key =
 ;app.administrative_tools_url = http://172.17.0.1:3000/api/v1
 
 [development : production]
-; Herda configurações de banco de dados
+; Herda todas as configurações de produção
 
 [testing : development]
 ; Herda todas as configurações de desenvolvimento
 
 ; Use seções especificas para adicionar configs que distinguem entre tenants,
-; ex para o host http://tenant.ieducar.com.br/, pode-se usar esta seção
+; ex para o host https://tenant.ieducar.com.br/, pode-se usar esta seção
 ; que herda as configurações de production
-;
 [tenant.ieducar.com.br : production]
 app.database.dbname     = tenant
 app.locale.province     = SC


### PR DESCRIPTION
Quando estava testando o PR #369 ao executar os passos descritos no README, faltou o comando para copiar o arquivo `phinx.php`. 

Aproveitei para reorganizar os comandos a serem executados para iniciar o desenvolvimento e remover alguns comentários desnecessários do arquivo `ieducar.ini.sample`.