### PR TITLE
Corrige instalação de dependências via composer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     image: "composer"
     volumes:
       - ./:/app
-    command: install
+    command: install --ignore-platform-reqs
   postgres_95:
     volumes:
       - /var/lib/postgresql/data


### PR DESCRIPTION
Composer não está efetuando a instalação das dependências. A imagem do docker composer é PHP 7.2 e há pacotes que exigem PHP 7.0, gerando erro.
Adicionado parâmetro para forçar instalação mesmo que não atenda os requisitos. Solução paliativa.