### PR TITLE
Patch de ajustes para uso de relatórios

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
   "require": {
     "php": "7.0.*",
     "cocur/slugify": "^3.1",
+    "cossou/jasperphp": "^2.7",
     "gilbitron/php-simplecache": "^1.4",
     "google/recaptcha": "~1.1",
     "honeybadger-io/honeybadger-php": "^0.4.1",
-    "portabilis/jasperphp": "v1.2.0",
     "robmorgan/phinx": "v0.8.1",
     "swiftmailer/swiftmailer": "^6.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0eecc02417427980c672f6ce7ff3a400",
+    "content-hash": "aa85d1f1ac8df2571a407628efaa31a9",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -70,6 +70,47 @@
                 "slugify"
             ],
             "time": "2018-01-22T09:00:48+00:00"
+        },
+        {
+            "name": "cossou/jasperphp",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cossou/JasperPHP.git",
+                "reference": "afda44a9a6a8602966e982709db80408f36e0b6d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cossou/JasperPHP/zipball/afda44a9a6a8602966e982709db80408f36e0b6d",
+                "reference": "afda44a9a6a8602966e982709db80408f36e0b6d",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JasperPHP": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Hélder Duarte",
+                    "email": "cossou@gmail.com"
+                }
+            ],
+            "description": "Create Reports in PHP with JasperReports",
+            "homepage": "https://github.com/cossou/JasperPHP",
+            "keywords": [
+                "jasper",
+                "jasperreports",
+                "java",
+                "pdf",
+                "reports"
+            ],
+            "time": "2018-06-14T10:32:13+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -514,47 +555,6 @@
                 "reporting"
             ],
             "time": "2018-06-12T13:43:02+00:00"
-        },
-        {
-            "name": "portabilis/jasperphp",
-            "version": "v1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/portabilis/JasperPHP.git",
-                "reference": "af3fa091e4a0f2bf20cac7c257990f6b851f26fe"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/portabilis/JasperPHP/zipball/af3fa091e4a0f2bf20cac7c257990f6b851f26fe",
-                "reference": "af3fa091e4a0f2bf20cac7c257990f6b851f26fe",
-                "shasum": ""
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "JasperPHP": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Hélder Duarte",
-                    "email": "cossou@gmail.com"
-                }
-            ],
-            "description": "Create Reports in PHP with JasperReports",
-            "homepage": "https://github.com/portabilis/JasperPHP",
-            "keywords": [
-                "jasper",
-                "jasperreports",
-                "java",
-                "pdf",
-                "reports"
-            ],
-            "time": "2018-04-02T20:16:55+00:00"
         },
         {
             "name": "psr/http-message",

--- a/ieducar/configuration/ieducar.ini.sample
+++ b/ieducar/configuration/ieducar.ini.sample
@@ -98,8 +98,10 @@ report.logo_file_name = brasil.png
 report.show_error_details = true
 
 ; Define a fabrica de relatórios padrão
-;report.default_factory = Portabilis_Report_ReportFactoryPHPJasperXML
 report.default_factory = Portabilis_Report_ReportFactoryPHPJasper
+
+; Define o diretório dos arquivos fontes dos relatórios
+report.source_path = /home/portabilis/ieducar/ieducar/modules/Reports/ReportSources
 
 ; Configurações da entidade (instituicao)
 ; define o nome da entidade a ser exibido no topo

--- a/ieducar/lib/Portabilis/Controller/ReportCoreController.php
+++ b/ieducar/lib/Portabilis/Controller/ReportCoreController.php
@@ -1,37 +1,5 @@
 <?php
 
-#error_reporting(E_ALL);
-#ini_set("display_errors", 1);
-
-/**
- * i-Educar - Sistema de gestão escolar
- *
- * Copyright (C) 2006  Prefeitura Municipal de Itajaí
- *                     <ctima@itajai.sc.gov.br>
- *
- * Este programa é software livre; você pode redistribuí-lo e/ou modificá-lo
- * sob os termos da Licença Pública Geral GNU conforme publicada pela Free
- * Software Foundation; tanto a versão 2 da Licença, como (a seu critério)
- * qualquer versão posterior.
- *
- * Este programa é distribuí­do na expectativa de que seja útil, porém, SEM
- * NENHUMA GARANTIA; nem mesmo a garantia implí­cita de COMERCIABILIDADE OU
- * ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral
- * do GNU para mais detalhes.
- *
- * Você deve ter recebido uma cópia da Licença Pública Geral do GNU junto
- * com este programa; se não, escreva para a Free Software Foundation, Inc., no
- * endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.
- *
- * @author      Lucas D'Avila <lucasdavila@portabilis.com.br>
- * @category    i-Educar
- * @license     @@license@@
- * @package     Controller
- * @subpackage  Portabilis
- * @since       Arquivo disponível desde a versão 1.1.0
- * @version     $Id$
- */
-
 use iEducar\Modules\ErrorTracking\TrackerFactory;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
@@ -41,212 +9,202 @@ require_once 'Avaliacao/Model/NotaComponenteDataMapper.php';
 require_once 'lib/Portabilis/String/Utils.php';
 require_once 'include/pmieducar/clsPermissoes.inc.php';
 
-/**
- * Portabilis_Controller_ReportCoreController class.
- *
- * @author      Lucas D'Avila <lucasdavila@portabilis.com.br>
- * @category    i-Educar
- * @license     @@license@@
- * @package     Controller
- * @subpackage  Portabilis
- * @since       Classe disponível desde a versão 1.1.0
- * @version     @@package_version@@
- */
 class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_EditController
 {
 
-  // setado qualquer dataMapper pois é obrigatório.
-  protected $_dataMapper = 'Avaliacao_Model_NotaComponenteDataMapper';
+    // setado qualquer dataMapper pois é obrigatório.
+    protected $_dataMapper = 'Avaliacao_Model_NotaComponenteDataMapper';
 
-  # 624 código permissão página index, por padrão todos usuários tem permissão.
-  protected $_processoAp = 624;
+    # 624 código permissão página index, por padrão todos usuários tem permissão.
+    protected $_processoAp = 624;
 
-  protected $_titulo     = 'Relat&oacute;rio';
+    protected $_titulo = 'Relat&oacute;rio';
 
-  public function __construct() {
-    $this->validatesIfUserIsLoggedIn();
+    public function __construct()
+    {
+        $this->validatesIfUserIsLoggedIn();
 
-    $this->validationErrors   = array();
+        $this->validationErrors = [];
 
-    // clsCadastro settings
-    $this->acao_executa_submit = false;
-    $this->acao_enviar         = 'printReport()';
+        // clsCadastro settings
+        $this->acao_executa_submit = false;
+        $this->acao_enviar = 'printReport()';
 
-    header('Content-Type: text/html; charset=utf-8');
+        header('Content-Type: text/html; charset=utf-8');
 
-    parent::__construct();
-  }
-
-
-  public function Gerar() {
-    if (count($_POST) < 1 && !isset($_GET['print_report_with_get'])) {
-      $this->appendFixups();
-      $this->renderForm();
-    }
-    else {
-      $this->report = $this->report();
-
-      $this->beforeValidation();
-
-      if (CORE_EXT_CONFIGURATION_ENV == "production") {
-        $this->report->addArg('SUBREPORT_DIR', "/sites_media_root/services/reports/jasper/");
-      } else if (CORE_EXT_CONFIGURATION_ENV == "development") {
-        $this->report->addArg('SUBREPORT_DIR', __DIR__ . '/../../../modules/Reports/ReportSources/Portabilis/');
-      } else {
-        $this->report->addArg('SUBREPORT_DIR', "/sites_media_root/services-test/reports/jasper/");
-      }
-
-      $this->report->addArg('database', ($GLOBALS['coreExt']['Config']->app->database->dbname == 'test' ? (is_null($GLOBALS['coreExt']['Config']->report->database_teste) ? "" : $GLOBALS['coreExt']['Config']->report->database_teste)  : $GLOBALS['coreExt']['Config']->app->database->dbname ));
-
-      $this->report->addArg('data_emissao', (int) $GLOBALS['coreExt']['Config']->report->header->show_data_emissao);
-      $this->validatesPresenseOfRequiredArgsInReport();
-      $this->aftervalidation();
-
-      if (count($this->validationErrors) > 0)
-        $this->onValidationError();
-      else
-        $this->renderReport();
-
-    }
-  }
-
-
-  function headers($result) {
-
-    header("Pragma: public");
-    header("Expires: 0");
-    header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
-    header("Cache-Control: private",false);
-    header("Content-Type: application/pdf;");
-    header("Content-Disposition: inline;");
-    header("Content-Transfer-Encoding: binary");
-    header("Content-Length: " . strlen($result));
-  }
-
-
-  function renderForm() {
-    $this->form();
-    $this->nome_url_sucesso = "Exibir";
-  }
-
-
-  function renderReport() {
-    try {
-      $result = $this->report->dumps();
-
-      if (! $result)
-        throw new Exception('No report result to render!');
-
-      $this->headers($result);
-      ob_clean();
-      flush();
-      echo $result;
-    }
-    catch (Exception $e) {
-
-      if ($GLOBALS['coreExt']['Config']->modules->error->track) {
-          $tracker = TrackerFactory::getTracker($GLOBALS['coreExt']['Config']->modules->error->tracker_name);
-          $tracker->notify($e);
-      }
-
-      $nivelUsuario = (new clsPermissoes)->nivel_acesso($this->getSession()->id_pessoa);
-
-      if ((bool) $GLOBALS['coreExt']['Config']->report->show_error_details === true || (int) $nivelUsuario === 1) {
-        $details = 'Detalhes: ' . $e->getMessage();
-      } else {
-        $details = "Visualização dos detalhes sobre o erro desativada.";
-      }
-
-      $this->renderError($details);
-    }
-  }
-
-
-  // methods that must be overridden
-
-  function form() {
-    throw new Exception("The method 'form' must be overridden!");
-  }
-
-
-  // metodo executado após validação com sucesso (antes de imprimir) , como os argumentos ex: $this->addArg('id', 1); $this->addArg('id_2', 2);
-  function beforeValidation() {
-    throw new Exception("The method 'beforeValidation' must be overridden!");
-  }
-
-
-  // methods that can be overridden
-
-  function afterValidation() {
-    //colocar aqui as validacoes serverside, exemplo se histórico possui todos os campos...
-    //retornar dict msgs, se nenhuma msg entao esta validado ex: $this->addValidationError('O cadastro x esta em y status');
-  }
-
-
-
-  protected function validatesIfUserIsLoggedIn() {
-    if (! $this->getSession()->id_pessoa)
-      header('Location: logof.php');
-  }
-
-
-  function addValidationError($message) {
-    $this->validationErrors[] = array('message' => utf8_encode($message));
-  }
-
-
-  function validatesPresenseOfRequiredArgsInReport() {
-    foreach($this->report->requiredArgs as $requiredArg) {
-
-      if (! isset($this->report->args[$requiredArg]) || empty($this->report->args[$requiredArg]))
-        $this->addValidationError('Informe um valor no campo "' . $requiredArg . '"');
-    }
-  }
-
-
-  function onValidationError() {
-    $msg = Portabilis_String_Utils::toLatin1('O relatório não pode ser emitido, dica(s):').'\n\n';
-
-    foreach ($this->validationErrors as $e) {
-      $error = $e['message'];
-      $msg .= '- ' . $error . '\n';
+        parent::__construct();
     }
 
-    $msg .= '\n'.Portabilis_String_Utils::toLatin1('Por favor, verifique esta(s) situação(s) e tente novamente.');
+    public function Gerar()
+    {
+        if (count($_POST) < 1 && !isset($_GET['print_report_with_get'])) {
+            $this->appendFixups();
+            $this->renderForm();
+        } else {
+            $this->report = $this->report();
 
-    $msg = Portabilis_String_Utils::toLatin1($msg, array('escape' => false));
-    echo "<script type='text/javascript'>alert('$msg'); close();</script> ";
-  }
+            $this->beforeValidation();
 
+            if (CORE_EXT_CONFIGURATION_ENV == 'production') {
+                $this->report->addArg('SUBREPORT_DIR', '/sites_media_root/services/reports/jasper/');
+            } elseif (CORE_EXT_CONFIGURATION_ENV == 'development') {
+                $this->report->addArg('SUBREPORT_DIR', __DIR__ . '/../../../modules/Reports/ReportSources/Portabilis/');
+            } else {
+                $this->report->addArg('SUBREPORT_DIR', '/sites_media_root/services-test/reports/jasper/');
+            }
 
-  function renderError($details = "") {
-    $details = Portabilis_String_Utils::escape($details);
-    $msg     = Portabilis_String_Utils::toLatin1('Ocorreu um erro ao emitir o relatório.') . '\n\n' . $details;
+            $this->report->addArg('database', ($GLOBALS['coreExt']['Config']->app->database->dbname == 'test' ? (is_null($GLOBALS['coreExt']['Config']->report->database_teste) ? '' : $GLOBALS['coreExt']['Config']->report->database_teste) : $GLOBALS['coreExt']['Config']->app->database->dbname));
 
-    $msg = Portabilis_String_Utils::toLatin1($msg, array('escape' => false));
-    $msg = "<script type='text/javascript'>alert('$msg'); close();</script>";
+            $this->report->addArg('data_emissao', (int)$GLOBALS['coreExt']['Config']->report->header->show_data_emissao);
+            $this->validatesPresenseOfRequiredArgsInReport();
+            $this->aftervalidation();
 
-    echo $msg;
-  }
+            if (count($this->validationErrors) > 0) {
+                $this->onValidationError();
+            } else {
+                $this->renderReport();
+            }
+        }
+    }
 
-  protected function loadResourceAssets($dispatcher) {
-    $rootPath       = $_SERVER['DOCUMENT_ROOT'];
-    $controllerName = ucwords($dispatcher->getControllerName());
-    $actionName     = ucwords($dispatcher->getActionName());
+    public function headers($result)
+    {
+        header('Pragma: public');
+        header('Expires: 0');
+        header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
+        header('Cache-Control: private', false);
+        header('Content-Type: application/pdf;');
+        header('Content-Disposition: inline;');
+        header('Content-Transfer-Encoding: binary');
+        header('Content-Length: ' . strlen($result));
+    }
 
-    $style          = "/modules/$controllerName/Assets/Stylesheets/$actionName.css";
-    $script         = "/modules/$controllerName/Assets/Javascripts/$actionName.js";
+    public function renderForm()
+    {
+        $this->form();
+        $this->nome_url_sucesso = 'Exibir';
+    }
 
-    if (file_exists($rootPath . $style))
-      Portabilis_View_Helper_Application::loadStylesheet($this, $style);
+    public function renderReport()
+    {
+        try {
+            $result = $this->report->dumps();
 
-    if (file_exists($rootPath . $script))
-      Portabilis_View_Helper_Application::loadJavascript($this, $script);
-  }
+            if (!$result) {
+                throw new Exception('No report result to render!');
+            }
 
+            $this->headers($result);
+            ob_clean();
+            flush();
+            echo $result;
+        } catch (Exception $e) {
+            if ($GLOBALS['coreExt']['Config']->modules->error->track) {
+                $tracker = TrackerFactory::getTracker($GLOBALS['coreExt']['Config']->modules->error->tracker_name);
+                $tracker->notify($e);
+            }
 
-  function appendFixups() {
-    $js = <<<EOT
+            $nivelUsuario = (new clsPermissoes)->nivel_acesso($this->getSession()->id_pessoa);
+
+            if ((bool)$GLOBALS['coreExt']['Config']->report->show_error_details === true || (int)$nivelUsuario === 1) {
+                $details = 'Detalhes: ' . $e->getMessage();
+            } else {
+                $details = 'Visualização dos detalhes sobre o erro desativada.';
+            }
+
+            $this->renderError($details);
+        }
+    }
+
+    // methods that must be overridden
+
+    public function form()
+    {
+        throw new Exception('The method \'form\' must be overridden!');
+    }
+
+    // metodo executado após validação com sucesso (antes de imprimir) , como os argumentos ex: $this->addArg('id', 1); $this->addArg('id_2', 2);
+    public function beforeValidation()
+    {
+        throw new Exception('The method \'beforeValidation\' must be overridden!');
+    }
+
+    // methods that can be overridden
+
+    public function afterValidation()
+    {
+        //colocar aqui as validacoes serverside, exemplo se histórico possui todos os campos...
+        //retornar dict msgs, se nenhuma msg entao esta validado ex: $this->addValidationError('O cadastro x esta em y status');
+    }
+
+    protected function validatesIfUserIsLoggedIn()
+    {
+        if (!$this->getSession()->id_pessoa) {
+            header('Location: logof.php');
+        }
+    }
+
+    public function addValidationError($message)
+    {
+        $this->validationErrors[] = ['message' => utf8_encode($message)];
+    }
+
+    public function validatesPresenseOfRequiredArgsInReport()
+    {
+        foreach ($this->report->requiredArgs as $requiredArg) {
+            if (!isset($this->report->args[$requiredArg]) || empty($this->report->args[$requiredArg])) {
+                $this->addValidationError('Informe um valor no campo "' . $requiredArg . '"');
+            }
+        }
+    }
+
+    public function onValidationError()
+    {
+        $msg = Portabilis_String_Utils::toLatin1('O relatório não pode ser emitido, dica(s):') . '\n\n';
+
+        foreach ($this->validationErrors as $e) {
+            $error = $e['message'];
+            $msg .= '- ' . $error . '\n';
+        }
+
+        $msg .= '\n' . Portabilis_String_Utils::toLatin1('Por favor, verifique esta(s) situação(s) e tente novamente.');
+
+        $msg = Portabilis_String_Utils::toLatin1($msg, ['escape' => false]);
+        echo "<script type='text/javascript'>alert('$msg'); close();</script> ";
+    }
+
+    public function renderError($details = '')
+    {
+        $details = Portabilis_String_Utils::escape($details);
+        $msg = Portabilis_String_Utils::toLatin1('Ocorreu um erro ao emitir o relatório.') . '\n\n' . $details;
+
+        $msg = Portabilis_String_Utils::toLatin1($msg, ['escape' => false]);
+        $msg = "<script type='text/javascript'>alert('$msg'); close();</script>";
+
+        echo $msg;
+    }
+
+    protected function loadResourceAssets($dispatcher)
+    {
+        $rootPath = $_SERVER['DOCUMENT_ROOT'];
+        $controllerName = ucwords($dispatcher->getControllerName());
+        $actionName = ucwords($dispatcher->getActionName());
+
+        $style = "/modules/$controllerName/Assets/Stylesheets/$actionName.css";
+        $script = "/modules/$controllerName/Assets/Javascripts/$actionName.js";
+
+        if (file_exists($rootPath . $style)) {
+            Portabilis_View_Helper_Application::loadStylesheet($this, $style);
+        }
+
+        if (file_exists($rootPath . $script)) {
+            Portabilis_View_Helper_Application::loadJavascript($this, $script);
+        }
+    }
+
+    public function appendFixups()
+    {
+        $js = <<<EOT
 
 <script type="text/javascript">
   function printReport() {
@@ -260,6 +218,6 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
 </script>
 
 EOT;
-    $this->appendOutput($js);
-  }
+        $this->appendOutput($js);
+    }
 }

--- a/ieducar/lib/Portabilis/Controller/ReportCoreController.php
+++ b/ieducar/lib/Portabilis/Controller/ReportCoreController.php
@@ -11,15 +11,29 @@ require_once 'include/pmieducar/clsPermissoes.inc.php';
 
 class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_EditController
 {
-
-    // setado qualquer dataMapper pois é obrigatório.
+    /**
+     * Setado qualquer Data Mapper pois é obrigatório.
+     *
+     * @var string
+     */
     protected $_dataMapper = 'Avaliacao_Model_NotaComponenteDataMapper';
 
-    # 624 código permissão página index, por padrão todos usuários tem permissão.
+    /**
+     * Código de permissão da página index, por padrão todos usuários tem
+     * permissão.
+     *
+     * @var int
+     */
     protected $_processoAp = 624;
 
-    protected $_titulo = 'Relat&oacute;rio';
+    /**
+     * @var string
+     */
+    protected $_titulo = 'Relatório';
 
+    /**
+     * Portabilis_Controller_ReportCoreController constructor.
+     */
     public function __construct()
     {
         $this->validatesIfUserIsLoggedIn();
@@ -35,6 +49,15 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
         parent::__construct();
     }
 
+    /**
+     * Método padrão da clsCadastro.
+     *
+     * @see clsCadastro::Gerar()
+     *
+     * @return bool|void
+     *
+     * @throws Exception
+     */
     public function Gerar()
     {
         if (count($_POST) < 1 && !isset($_GET['print_report_with_get'])) {
@@ -67,6 +90,13 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
         }
     }
 
+    /**
+     * Altera os headers que irão na resposta da requisição.
+     *
+     * @param string $result
+     *
+     * @return void
+     */
     public function headers($result)
     {
         header('Pragma: public');
@@ -79,12 +109,26 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
         header('Content-Length: ' . strlen($result));
     }
 
+    /**
+     * Renderiza o formulário de filtragem.
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
     public function renderForm()
     {
         $this->form();
         $this->nome_url_sucesso = 'Exibir';
     }
 
+    /**
+     * Renderiza o relatório.
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
     public function renderReport()
     {
         try {
@@ -116,39 +160,84 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
         }
     }
 
-    // methods that must be overridden
-
+    /**
+     * Monta o formulário de filtragem.
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
     public function form()
     {
         throw new Exception('The method \'form\' must be overridden!');
     }
 
-    // metodo executado após validação com sucesso (antes de imprimir) , como os argumentos ex: $this->addArg('id', 1); $this->addArg('id_2', 2);
+    /**
+     * Método executado após validar com sucesso (antes de imprimir), os
+     * argumentos.
+     *
+     *  <code>
+     *      $this->addArg('id', 1);
+     *      $this->addArg('id_2', 2);
+     *  </code>
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
     public function beforeValidation()
     {
         throw new Exception('The method \'beforeValidation\' must be overridden!');
     }
 
-    // methods that can be overridden
-
+    /**
+     * Colocar aqui as validacoes serverside, exemplo se histórico possui todos
+     * os campos. Retornar mensagens, se não existe nenhuma mensagem, então
+     * está validado.
+     *
+     *  <code>
+     *      $this->addValidationError('O cadastro x esta em y status');
+     *  </code>
+     *
+     * @return void
+     */
     public function afterValidation()
     {
-        //colocar aqui as validacoes serverside, exemplo se histórico possui todos os campos...
-        //retornar dict msgs, se nenhuma msg entao esta validado ex: $this->addValidationError('O cadastro x esta em y status');
     }
 
+    /**
+     * Valida se o usuário está logado, caso contrário redireciona para a
+     * página de logoff.
+     *
+     * @return void
+     */
     protected function validatesIfUserIsLoggedIn()
     {
         if (!$this->getSession()->id_pessoa) {
             header('Location: logof.php');
+            die();
         }
     }
 
+    /**
+     * Adiciona uma mensagem de erro de validação.
+     *
+     * @param string $message
+     *
+     * @return void
+     */
     public function addValidationError($message)
     {
-        $this->validationErrors[] = ['message' => utf8_encode($message)];
+        $this->validationErrors[] = [
+            'message' => utf8_encode($message)
+        ];
     }
 
+    /**
+     * Valida se todos os parâmetros obrigatórios foram informados.
+     *
+     * @return void
+     */
     public function validatesPresenseOfRequiredArgsInReport()
     {
         foreach ($this->report->requiredArgs as $requiredArg) {
@@ -158,6 +247,11 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
         }
     }
 
+    /**
+     * Exibe mensagem em caso de erro.
+     *
+     * @return void
+     */
     public function onValidationError()
     {
         $msg = Portabilis_String_Utils::toLatin1('O relatório não pode ser emitido, dica(s):') . '\n\n';
@@ -173,6 +267,13 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
         echo "<script type='text/javascript'>alert('$msg'); close();</script> ";
     }
 
+    /**
+     * Renderiza uma mensagem de erro.
+     *
+     * @param string $details
+     *
+     * @return void
+     */
     public function renderError($details = '')
     {
         $details = Portabilis_String_Utils::escape($details);
@@ -184,6 +285,13 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
         echo $msg;
     }
 
+    /**
+     * Carrega assets utilizados.
+     *
+     * @param object $dispatcher
+     *
+     * @return void
+     */
     protected function loadResourceAssets($dispatcher)
     {
         $rootPath = $_SERVER['DOCUMENT_ROOT'];
@@ -202,6 +310,11 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
         }
     }
 
+    /**
+     * Adiciona JavaScript a página.
+     *
+     * @return void
+     */
     public function appendFixups()
     {
         $js = <<<EOT

--- a/ieducar/lib/Portabilis/Controller/ReportCoreController.php
+++ b/ieducar/lib/Portabilis/Controller/ReportCoreController.php
@@ -73,17 +73,10 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
 
             $this->beforeValidation();
 
-            if (CORE_EXT_CONFIGURATION_ENV == 'production') {
-                $this->report->addArg('SUBREPORT_DIR', '/sites_media_root/services/reports/jasper/');
-            } elseif (CORE_EXT_CONFIGURATION_ENV == 'development') {
-                $this->report->addArg('SUBREPORT_DIR', __DIR__ . '/../../../modules/Reports/ReportSources/Portabilis/');
-            } else {
-                $this->report->addArg('SUBREPORT_DIR', '/sites_media_root/services-test/reports/jasper/');
-            }
-
             $this->report->addArg('database', ($GLOBALS['coreExt']['Config']->app->database->dbname == 'test' ? (is_null($GLOBALS['coreExt']['Config']->report->database_teste) ? '' : $GLOBALS['coreExt']['Config']->report->database_teste) : $GLOBALS['coreExt']['Config']->app->database->dbname));
-
+            $this->report->addArg('SUBREPORT_DIR', $GLOBALS['coreExt']['Config']->report->source_path);
             $this->report->addArg('data_emissao', (int) $GLOBALS['coreExt']['Config']->report->header->show_data_emissao);
+
             $this->validatesPresenseOfRequiredArgsInReport();
             $this->aftervalidation();
 

--- a/ieducar/lib/Portabilis/Controller/ReportCoreController.php
+++ b/ieducar/lib/Portabilis/Controller/ReportCoreController.php
@@ -32,6 +32,11 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
     protected $_titulo = 'Relatório';
 
     /**
+     * @var Portabilis_Report_ReportCore
+     */
+    protected $report;
+
+    /**
      * Portabilis_Controller_ReportCoreController constructor.
      */
     public function __construct()
@@ -78,7 +83,7 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
 
             $this->report->addArg('database', ($GLOBALS['coreExt']['Config']->app->database->dbname == 'test' ? (is_null($GLOBALS['coreExt']['Config']->report->database_teste) ? '' : $GLOBALS['coreExt']['Config']->report->database_teste) : $GLOBALS['coreExt']['Config']->app->database->dbname));
 
-            $this->report->addArg('data_emissao', (int)$GLOBALS['coreExt']['Config']->report->header->show_data_emissao);
+            $this->report->addArg('data_emissao', (int) $GLOBALS['coreExt']['Config']->report->header->show_data_emissao);
             $this->validatesPresenseOfRequiredArgsInReport();
             $this->aftervalidation();
 
@@ -150,7 +155,7 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
 
             $nivelUsuario = (new clsPermissoes)->nivel_acesso($this->getSession()->id_pessoa);
 
-            if ((bool)$GLOBALS['coreExt']['Config']->report->show_error_details === true || (int)$nivelUsuario === 1) {
+            if ((bool) $GLOBALS['coreExt']['Config']->report->show_error_details === true || (int) $nivelUsuario === 1) {
                 $details = 'Detalhes: ' . $e->getMessage();
             } else {
                 $details = 'Visualização dos detalhes sobre o erro desativada.';

--- a/ieducar/lib/Portabilis/Report/ReportCore.php
+++ b/ieducar/lib/Portabilis/Report/ReportCore.php
@@ -146,4 +146,36 @@ abstract class Portabilis_Report_ReportCore
      * @return void
      */
     abstract public function requiredArgs();
+
+    /**
+     * Indica se JSON será utilizado como fonte de dados para o relatório.
+     *
+     * @return bool
+     */
+    public function useJson()
+    {
+        return false;
+    }
+
+    /**
+     * Retorna a query onde será encontrado os dados para o relatório
+     * principal.
+     *
+     * @return string
+     */
+    public function getJsonQuery()
+    {
+        return '';
+    }
+
+    /**
+     * Array com os dados que serão convertidos em JSON e enviados ao relatório
+     * como fonte de dados.
+     *
+     * @return array
+     */
+    public function getJsonData()
+    {
+        return [];
+    }
 }

--- a/ieducar/lib/Portabilis/Report/ReportCore.php
+++ b/ieducar/lib/Portabilis/Report/ReportCore.php
@@ -1,115 +1,82 @@
 <?php
 
-/**
- * i-Educar - Sistema de gestão escolar
- *
- * Copyright (C) 2006  Prefeitura Municipal de Itajaí
- *                     <ctima@itajai.sc.gov.br>
- *
- * Este programa é software livre; você pode redistribuí-lo e/ou modificá-lo
- * sob os termos da Licença Pública Geral GNU conforme publicada pela Free
- * Software Foundation; tanto a versão 2 da Licença, como (a seu critério)
- * qualquer versão posterior.
- *
- * Este programa é distribuí­do na expectativa de que seja útil, porém, SEM
- * NENHUMA GARANTIA; nem mesmo a garantia implí­cita de COMERCIABILIDADE OU
- * ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral
- * do GNU para mais detalhes.
- *
- * Você deve ter recebido uma cópia da Licença Pública Geral do GNU junto
- * com este programa; se não, escreva para a Free Software Foundation, Inc., no
- * endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.
- *
- * @author    Lucas D'Avila <lucasdavila@portabilis.com.br>
- * @category  i-Educar
- * @license   @@license@@
- * @package   Portabilis
- * @since     Arquivo disponível desde a versão 1.1.0
- * @version   $Id$
- */
-
 require_once 'lib/Portabilis/Array/Utils.php';
-
-/**
- * Portabilis_Report_ReportCore class.
- *
- * @author    Lucas D'Avila <lucasdavila@portabilis.com.br>
- * @category  i-Educar
- * @license   @@license@@
- * @package   Portabilis
- * @since     Classe disponível desde a versão 1.1.0
- * @version   @@package_version@@
- */
 
 class Portabilis_Report_ReportCore
 {
+    public function __construct()
+    {
+        $this->requiredArgs = [];
+        $this->args = [];
 
- function __construct() {
-    $this->requiredArgs = array();
-    $this->args         = array();
-
-    // set required args on construct, because ReportCoreController access it args before call dumps
-    $this->requiredArgs();
-  }
-
-  // wrapper for Portabilis_Array_Utils::merge
-  protected static function mergeOptions($options, $defaultOptions) {
-    return Portabilis_Array_Utils::merge($options, $defaultOptions);
-  }
-
-  function addArg($name, $value) {
-    if (is_string($value))
-      $value = $value;
-
-    $this->args[$name] = $value;
-  }
-
-  function addRequiredArg($name) {
-    $this->requiredArgs[] = $name;
-  }
-
-  function validatesPresenseOfRequiredArgs() {
-    foreach($this->requiredArgs as $requiredArg) {
-
-      if (! isset($this->args[$requiredArg]) || empty($this->args[$requiredArg]))
-        throw new Exception("The required arg '{$requiredArg}' wasn't set or is empty!");
+        $this->requiredArgs();
     }
-  }
 
-  function dumps($options = array()) {
-    $defaultOptions = array('report_factory' => null, 'options' => array());
-    $options        = self::mergeOptions($options, $defaultOptions);
+    protected static function mergeOptions($options, $defaultOptions)
+    {
+        return Portabilis_Array_Utils::merge($options, $defaultOptions);
+    }
 
-    $this->validatesPresenseOfRequiredArgs();
+    public function addArg($name, $value)
+    {
+        if (is_string($value)) {
+            $value = $value;
+        }
 
-    $reportFactory = ! is_null($options['report_factory']) ? $options['report_factory'] : $this->reportFactory();
+        $this->args[$name] = $value;
+    }
 
-    return $reportFactory->dumps($this, $options['options']);
-  }
+    public function addRequiredArg($name)
+    {
+        $this->requiredArgs[] = $name;
+    }
 
-  function reportFactory() {
-    $factoryClassName = $GLOBALS['coreExt']['Config']->report->default_factory;
-    $factoryClassPath = str_replace('_', '/', $factoryClassName) . '.php';
+    public function validatesPresenseOfRequiredArgs()
+    {
+        foreach ($this->requiredArgs as $requiredArg) {
+            if (!isset($this->args[$requiredArg]) || empty($this->args[$requiredArg])) {
+                throw new Exception("The required arg '{$requiredArg}' wasn't set or is empty!");
+            }
+        }
+    }
 
-    if (! $factoryClassName)
-      throw new CoreExt_Exception("No report.default_factory defined in configurations!");
+    public function dumps($options = [])
+    {
+        $defaultOptions = ['report_factory' => null, 'options' => []];
+        $options = self::mergeOptions($options, $defaultOptions);
 
-    // don't fail if path not exists.
-    include_once $factoryClassPath;
+        $this->validatesPresenseOfRequiredArgs();
 
-    if (! class_exists($factoryClassName))
-      throw new CoreExt_Exception("Class '$factoryClassName' not found in path '$factoryClassPath'");
+        $reportFactory = !is_null($options['report_factory']) ? $options['report_factory'] : $this->reportFactory();
 
-    return new $factoryClassName();
-  }
+        return $reportFactory->dumps($this, $options['options']);
+    }
 
-  // methods that must be overridden
+    public function reportFactory()
+    {
+        $factoryClassName = $GLOBALS['coreExt']['Config']->report->default_factory;
+        $factoryClassPath = str_replace('_', '/', $factoryClassName) . '.php';
 
-  function templateName() {
-    throw new Exception("The method 'templateName' must be overridden!");
-  }
+        if (!$factoryClassName) {
+            throw new CoreExt_Exception('No report.default_factory defined in configurations!');
+        }
 
-  function requiredArgs() {
-    throw new Exception("The method 'requiredArgs' must be overridden!");
-  }
+        include_once $factoryClassPath;
+
+        if (!class_exists($factoryClassName)) {
+            throw new CoreExt_Exception("Class '$factoryClassName' not found in path '$factoryClassPath'");
+        }
+
+        return new $factoryClassName();
+    }
+
+    public function templateName()
+    {
+        throw new Exception('The method \'templateName\' must be overridden!');
+    }
+
+    public function requiredArgs()
+    {
+        throw new Exception('The method \'requiredArgs\' must be overridden!');
+    }
 }

--- a/ieducar/lib/Portabilis/Report/ReportCore.php
+++ b/ieducar/lib/Portabilis/Report/ReportCore.php
@@ -4,6 +4,21 @@ require_once 'lib/Portabilis/Array/Utils.php';
 
 class Portabilis_Report_ReportCore
 {
+    /**
+     * @var array
+     */
+    public $requiredArgs;
+
+    /**
+     * @var array
+     */
+    public $args;
+
+    /**
+     * Portabilis_Report_ReportCore constructor.
+     *
+     * @throws Exception
+     */
     public function __construct()
     {
         $this->requiredArgs = [];
@@ -12,25 +27,53 @@ class Portabilis_Report_ReportCore
         $this->requiredArgs();
     }
 
+    /**
+     * Wrapper para Portabilis_Array_Utils::merge.
+     *
+     * @see Portabilis_Array_Utils::merge()
+     *
+     * @param array $options
+     * @param array $defaultOptions
+     *
+     * @return array
+     */
     protected static function mergeOptions($options, $defaultOptions)
     {
         return Portabilis_Array_Utils::merge($options, $defaultOptions);
     }
 
+    /**
+     * Adiciona um parâmetro para ser passado ao renderizador.
+     *
+     * @param string $name
+     * @param string $value
+     *
+     * @return void
+     */
     public function addArg($name, $value)
     {
-        if (is_string($value)) {
-            $value = $value;
-        }
-
         $this->args[$name] = $value;
     }
 
+    /**
+     * Adiciona o nome de um parâmetro obrigatório.
+     *
+     * @param string $name
+     *
+     * @return void
+     */
     public function addRequiredArg($name)
     {
         $this->requiredArgs[] = $name;
     }
 
+    /**
+     * Valida a existência de todos os parâmetros obrigatórios.
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
     public function validatesPresenseOfRequiredArgs()
     {
         foreach ($this->requiredArgs as $requiredArg) {
@@ -40,18 +83,37 @@ class Portabilis_Report_ReportCore
         }
     }
 
+    /**
+     * Renderiza o relatório.
+     *
+     * @param array $options
+     *
+     * @return mixed
+     *
+     * @throws CoreExt_Exception
+     * @throws Exception
+     */
     public function dumps($options = [])
     {
-        $defaultOptions = ['report_factory' => null, 'options' => []];
-        $options = self::mergeOptions($options, $defaultOptions);
+        $options = self::mergeOptions($options, [
+            'report_factory' => null,
+            'options' => []
+        ]);
 
         $this->validatesPresenseOfRequiredArgs();
 
-        $reportFactory = !is_null($options['report_factory']) ? $options['report_factory'] : $this->reportFactory();
+        $reportFactory = is_null($options['report_factory']) ? $this->reportFactory() : $options['report_factory'];
 
         return $reportFactory->dumps($this, $options['options']);
     }
 
+    /**
+     * Retorna uma fábrica de relatórios.
+     *
+     * @return Portabilis_Report_ReportFactory
+     *
+     * @throws CoreExt_Exception
+     */
     public function reportFactory()
     {
         $factoryClassName = $GLOBALS['coreExt']['Config']->report->default_factory;
@@ -70,11 +132,26 @@ class Portabilis_Report_ReportCore
         return new $factoryClassName();
     }
 
+    /**
+     * Retorna o nome do template (arquivo .jrxml) que será utilizado como
+     * template para a renderização.
+     *
+     * @return string
+     *
+     * @throws Exception
+     */
     public function templateName()
     {
         throw new Exception('The method \'templateName\' must be overridden!');
     }
 
+    /**
+     * Adiciona os parâmetros obrigatórios a serem passados ao renderizador.
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
     public function requiredArgs()
     {
         throw new Exception('The method \'requiredArgs\' must be overridden!');

--- a/ieducar/lib/Portabilis/Report/ReportCore.php
+++ b/ieducar/lib/Portabilis/Report/ReportCore.php
@@ -2,7 +2,7 @@
 
 require_once 'lib/Portabilis/Array/Utils.php';
 
-class Portabilis_Report_ReportCore
+abstract class Portabilis_Report_ReportCore
 {
     /**
      * @var array
@@ -137,23 +137,13 @@ class Portabilis_Report_ReportCore
      * template para a renderização.
      *
      * @return string
-     *
-     * @throws Exception
      */
-    public function templateName()
-    {
-        throw new Exception('The method \'templateName\' must be overridden!');
-    }
+    abstract public function templateName();
 
     /**
      * Adiciona os parâmetros obrigatórios a serem passados ao renderizador.
      *
      * @return void
-     *
-     * @throws Exception
      */
-    public function requiredArgs()
-    {
-        throw new Exception('The method \'requiredArgs\' must be overridden!');
-    }
+    abstract public function requiredArgs();
 }

--- a/ieducar/lib/Portabilis/Report/ReportFactory.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactory.php
@@ -2,10 +2,10 @@
 
 require_once 'lib/Portabilis/Array/Utils.php';
 
-class Portabilis_Report_ReportFactory
+abstract class Portabilis_Report_ReportFactory
 {
     /**
-     * @var array
+     * @var object
      */
     public $config;
 
@@ -48,13 +48,8 @@ class Portabilis_Report_ReportFactory
      * @param object $config
      *
      * @return void
-     *
-     * @throws Exception
      */
-    public function setSettings($config)
-    {
-        throw new Exception('The method \'setSettings\' from class Portabilis_Report_ReportFactory must be overridden!');
-    }
+    abstract public function setSettings($config);
 
     /**
      * Renderiza o relatório.
@@ -63,11 +58,6 @@ class Portabilis_Report_ReportFactory
      * @param array $options
      *
      * @return mixed
-     *
-     * @throws Exception
      */
-    public function dumps($report, $options = [])
-    {
-        throw new Exception('The method \'dumps\' from class Portabilis_Report_ReportFactory must be overridden!');
-    }
+    abstract public function dumps($report, $options = []);
 }

--- a/ieducar/lib/Portabilis/Report/ReportFactory.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactory.php
@@ -4,6 +4,21 @@ require_once 'lib/Portabilis/Array/Utils.php';
 
 class Portabilis_Report_ReportFactory
 {
+    /**
+     * @var array
+     */
+    public $config;
+
+    /**
+     * @var array
+     */
+    public $settings;
+
+    /**
+     * Portabilis_Report_ReportFactory constructor.
+     *
+     * @throws Exception
+     */
     public function __construct()
     {
         $this->config = $GLOBALS['coreExt']['Config'];
@@ -12,16 +27,45 @@ class Portabilis_Report_ReportFactory
         $this->setSettings($this->config);
     }
 
+    /**
+     * Wrapper para Portabilis_Array_Utils::merge.
+     *
+     * @see Portabilis_Array_Utils::merge()
+     *
+     * @param array $options
+     * @param array $defaultOptions
+     *
+     * @return array
+     */
     protected static function mergeOptions($options, $defaultOptions)
     {
         return Portabilis_Array_Utils::merge($options, $defaultOptions);
     }
 
+    /**
+     * Define as configurações dos relatórios.
+     *
+     * @param object $config
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
     public function setSettings($config)
     {
         throw new Exception('The method \'setSettings\' from class Portabilis_Report_ReportFactory must be overridden!');
     }
 
+    /**
+     * Renderiza o relatório.
+     *
+     * @param Portabilis_Report_ReportCore $report
+     * @param array $options
+     *
+     * @return mixed
+     *
+     * @throws Exception
+     */
     public function dumps($report, $options = [])
     {
         throw new Exception('The method \'dumps\' from class Portabilis_Report_ReportFactory must be overridden!');

--- a/ieducar/lib/Portabilis/Report/ReportFactory.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactory.php
@@ -1,66 +1,29 @@
 <?php
 
-/**
- * i-Educar - Sistema de gestão escolar
- *
- * Copyright (C) 2006  Prefeitura Municipal de Itajaí
- *                     <ctima@itajai.sc.gov.br>
- *
- * Este programa é software livre; você pode redistribuí-lo e/ou modificá-lo
- * sob os termos da Licença Pública Geral GNU conforme publicada pela Free
- * Software Foundation; tanto a versão 2 da Licença, como (a seu critério)
- * qualquer versão posterior.
- *
- * Este programa é distribuí­do na expectativa de que seja útil, porém, SEM
- * NENHUMA GARANTIA; nem mesmo a garantia implí­cita de COMERCIABILIDADE OU
- * ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral
- * do GNU para mais detalhes.
- *
- * Você deve ter recebido uma cópia da Licença Pública Geral do GNU junto
- * com este programa; se não, escreva para a Free Software Foundation, Inc., no
- * endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.
- *
- * @author    Lucas D'Avila <lucasdavila@portabilis.com.br>
- * @category  i-Educar
- * @license   @@license@@
- * @package   Portabilis
- * @since     Arquivo disponível desde a versão 1.1.0
- * @version   $Id$
- */
-
 require_once 'lib/Portabilis/Array/Utils.php';
-
-/**
- * Portabilis_Report_ReportFactory class.
- *
- * @author    Lucas D'Avila <lucasdavila@portabilis.com.br>
- * @category  i-Educar
- * @license   @@license@@
- * @package   Portabilis
- * @since     Classe disponível desde a versão 1.1.0
- * @version   @@package_version@@
- */
 
 class Portabilis_Report_ReportFactory
 {
-
-  function __construct() {
-        $this->config   = $GLOBALS['coreExt']['Config'];
-        $this->settings = array();
+    public function __construct()
+    {
+        $this->config = $GLOBALS['coreExt']['Config'];
+        $this->settings = [];
 
         $this->setSettings($this->config);
-  }
-
-  // wrapper for Portabilis_Array_Utils::merge
-  protected static function mergeOptions($options, $defaultOptions) {
-    return Portabilis_Array_Utils::merge($options, $defaultOptions);
-  }
-
-    function setSettings($config) {
-    throw new Exception("The method 'setSettings' from class Portabilis_Report_ReportFactory must be overridden!");
     }
 
-  function dumps($report, $options = array()) {
-    throw new Exception("The method 'dumps' from class Portabilis_Report_ReportFactory must be overridden!");
-  }
+    protected static function mergeOptions($options, $defaultOptions)
+    {
+        return Portabilis_Array_Utils::merge($options, $defaultOptions);
+    }
+
+    public function setSettings($config)
+    {
+        throw new Exception('The method \'setSettings\' from class Portabilis_Report_ReportFactory must be overridden!');
+    }
+
+    public function dumps($report, $options = [])
+    {
+        throw new Exception('The method \'dumps\' from class Portabilis_Report_ReportFactory must be overridden!');
+    }
 }

--- a/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
@@ -1,137 +1,103 @@
 <?php
- // error_reporting(E_ERROR);
- // ini_set("display_errors", 1);
-/**
- * i-Educar - Sistema de gestão escolar
- *
- * Copyright (C) 2006  Prefeitura Municipal de Itajaí
- *                     <ctima@itajai.sc.gov.br>
- *
- * Este programa é software livre; você pode redistribuí-lo e/ou modificá-lo
- * sob os termos da Licença Pública Geral GNU conforme publicada pela Free
- * Software Foundation; tanto a versão 2 da Licença, como (a seu critério)
- * qualquer versão posterior.
- *
- * Este programa é distribuí­do na expectativa de que seja útil, porém, SEM
- * NENHUMA GARANTIA; nem mesmo a garantia implí­cita de COMERCIABILIDADE OU
- * ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral
- * do GNU para mais detalhes.
- *
- * Você deve ter recebido uma cópia da Licença Pública Geral do GNU junto
- * com este programa; se não, escreva para a Free Software Foundation, Inc., no
- * endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.
- *
- * @author    Lucas Schmoeller da Silva <lucas@portabilis.com.br>
- * @category  i-Educar
- * @license   @@license@@
- * @package   Portabilis
- * @since     ?
- * @version   $Id$
- */
 
 require_once 'lib/Portabilis/Report/ReportFactory.php';
 require_once 'vendor/autoload.php';
-use JasperPHP\JasperPHP;
 
-/**
- * Portabilis_Report_ReportFactoryPHPJasper class.
- *
- * @author    Lucas Schmoeller da Silva <lucas@portabilis.com.br>
- * @category  i-Educar
- * @license   @@license@@
- * @package   Portabilis
- * @since     ?
- * @version   @@package_version@@
- */
+use JasperPHP\JasperPHP;
 
 class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportFactory
 {
-  function setSettings($config) {
-    $this->settings['db']             = $config->app->database;
-    $this->settings['logo_file_name'] = $config->report->logo_file_name;
-  }
-
-
-  function getReportsPath() {
-    $rootPath   = dirname(dirname(dirname(dirname(__FILE__))));
-    $reportsPath = $rootPath . "/modules/Reports/ReportSources/Portabilis/";
-
-    return $reportsPath;
-  }
-
-
-  function logoPath() {
-    if (! $this->settings['logo_file_name'])
-      throw new Exception("No report.logo_file_name defined in configurations!");
-
-    $rootPath = dirname(dirname(dirname(dirname(__FILE__))));
-    $filePath = $rootPath . "/modules/Reports/ReportLogos/{$this->settings['logo_file_name']}";
-
-    if (! file_exists($filePath))
-      throw new CoreExt_Exception("Report logo '{$this->settings['logo_file_name']}' not found in path '$filePath'");
-
-    return $filePath;
-  }
-
-
-  function dumps($report, $options = array()) {
-    $defaultOptions          = array('add_logo_arg' => true);
-    $options                 = self::mergeOptions($options, $defaultOptions);
-
-    if ($options['add_logo_arg'])
-      $report->addArg('logo', $this->logoPath());
-
-
-    // Generate a random file name
-    $outputFile = $this->getReportsPath() . time().'-'.mt_rand();;
-
-    // Corrige parametros boleanos
-    foreach ($report->args as $key => $value) {
-      if (is_bool($value)) {
-        $report->args[$key] = ($value ? 'true' : 'false');
-      }
+    public function setSettings($config)
+    {
+        $this->settings['db'] = $config->app->database;
+        $this->settings['logo_file_name'] = $config->report->logo_file_name;
     }
 
-    $builder = new JasperPHP();
-    $return = $builder->process(
-        $this->getReportsPath() . $report->templateName() . '.jasper',
-        $outputFile,
-        array("pdf"),
-        $report->args,
-        array(
-          'driver' => 'postgres',
-          'username' => $this->settings['db']->username,
-          'host' => $this->settings['db']->hostname,
-          'database' => $this->settings['db']->dbname,
-          'port' => $this->settings['db']->port,
-          'password' => $this->settings['db']->password,
-        ),
-        FALSE
-    )->execute();
+    public function getReportsPath()
+    {
+        $rootPath = dirname(dirname(dirname(dirname(__FILE__))));
+        $reportsPath = $rootPath . '/modules/Reports/ReportSources/Portabilis/';
 
-    $outputFile .= '.pdf';
+        return $reportsPath;
+    }
 
-    $this->showPDF($outputFile);
-    $this->destroyPDF($outputFile);
-  }
+    public function logoPath()
+    {
+        if (!$this->settings['logo_file_name']) {
+            throw new Exception('No report.logo_file_name defined in configurations!');
+        }
 
-  function showPDF($file){
-    header("Pragma: public");
-    header("Expires: 0");
-    header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
-    header("Cache-Control: private",false);
-    header("Content-Type: application/pdf;");
-    header("Content-Disposition: inline;");
-    header("Content-Transfer-Encoding: binary");
-    header("Content-Length: ".filesize($file));
+        $rootPath = dirname(dirname(dirname(dirname(__FILE__))));
+        $filePath = $rootPath . "/modules/Reports/ReportLogos/{$this->settings['logo_file_name']}";
 
-    ob_clean();
-    flush();
+        if (!file_exists($filePath)) {
+            throw new CoreExt_Exception("Report logo '{$this->settings['logo_file_name']}' not found in path '$filePath'");
+        }
 
-    readfile($file);
-  }
+        return $filePath;
+    }
 
-  function destroyPDF($file){
-    unlink($file);
-  }
+    public function dumps($report, $options = [])
+    {
+        $defaultOptions = ['add_logo_arg' => true];
+        $options = self::mergeOptions($options, $defaultOptions);
+
+        if ($options['add_logo_arg']) {
+            $report->addArg('logo', $this->logoPath());
+        }
+
+        // Generate a random file name
+        $outputFile = $this->getReportsPath() . time() . '-' . mt_rand();;
+
+        // Corrige parametros boleanos
+        foreach ($report->args as $key => $value) {
+            if (is_bool($value)) {
+                $report->args[$key] = ($value ? 'true' : 'false');
+            }
+        }
+
+        $builder = new JasperPHP();
+        $return = $builder->process(
+            $this->getReportsPath() . $report->templateName() . '.jasper',
+            $outputFile,
+            ['pdf'],
+            $report->args,
+            [
+                'driver' => 'postgres',
+                'username' => $this->settings['db']->username,
+                'host' => $this->settings['db']->hostname,
+                'database' => $this->settings['db']->dbname,
+                'port' => $this->settings['db']->port,
+                'password' => $this->settings['db']->password,
+            ],
+            false
+        )->execute();
+
+        $outputFile .= '.pdf';
+
+        $this->showPDF($outputFile);
+        $this->destroyPDF($outputFile);
+    }
+
+    public function showPDF($file)
+    {
+        header('Pragma: public');
+        header('Expires: 0');
+        header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
+        header('Cache-Control: private', false);
+        header('Content-Type: application/pdf;');
+        header('Content-Disposition: inline;');
+        header('Content-Transfer-Encoding: binary');
+        header('Content-Length: ' . filesize($file));
+
+        ob_clean();
+        flush();
+
+        readfile($file);
+    }
+
+    public function destroyPDF($file)
+    {
+        unlink($file);
+    }
 }

--- a/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
@@ -27,10 +27,7 @@ class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportF
      */
     public function getReportsPath()
     {
-        $rootPath = dirname(dirname(dirname(dirname(__FILE__))));
-        $reportsPath = $rootPath . '/modules/Reports/ReportSources/Portabilis/';
-
-        return $reportsPath;
+        return $GLOBALS['coreExt']['Config']->report->source_path;
     }
 
     /**

--- a/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
@@ -13,8 +13,6 @@ class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportF
      * @param object $config
      *
      * @return void
-     *
-     * @throws Exception
      */
     public function setSettings($config)
     {
@@ -66,7 +64,7 @@ class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportF
      * @param array $options
      *
      * @return void
-     *
+     * 
      * @throws Exception
      */
     public function dumps($report, $options = [])

--- a/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
@@ -7,12 +7,26 @@ use JasperPHP\JasperPHP;
 
 class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportFactory
 {
+    /**
+     * Define as configurações dos relatórios.
+     *
+     * @param object $config
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
     public function setSettings($config)
     {
         $this->settings['db'] = $config->app->database;
         $this->settings['logo_file_name'] = $config->report->logo_file_name;
     }
 
+    /**
+     * Retorna o diretório dos relatórios.
+     *
+     * @return string
+     */
     public function getReportsPath()
     {
         $rootPath = dirname(dirname(dirname(dirname(__FILE__))));
@@ -21,6 +35,14 @@ class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportF
         return $reportsPath;
     }
 
+    /**
+     * Retorna o arquivo da logo utilizada nos relatórios.
+     *
+     * @return string
+     *
+     * @throws CoreExt_Exception
+     * @throws Exception
+     */
     public function logoPath()
     {
         if (!$this->settings['logo_file_name']) {
@@ -37,19 +59,28 @@ class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportF
         return $filePath;
     }
 
+    /**
+     * Renderiza o relatório.
+     *
+     * @param Portabilis_Report_ReportCore $report
+     * @param array $options
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
     public function dumps($report, $options = [])
     {
-        $defaultOptions = ['add_logo_arg' => true];
-        $options = self::mergeOptions($options, $defaultOptions);
+        $options = self::mergeOptions($options, [
+            'add_logo_arg' => true
+        ]);
 
         if ($options['add_logo_arg']) {
             $report->addArg('logo', $this->logoPath());
         }
 
-        // Generate a random file name
         $outputFile = $this->getReportsPath() . time() . '-' . mt_rand();;
 
-        // Corrige parametros boleanos
         foreach ($report->args as $key => $value) {
             if (is_bool($value)) {
                 $report->args[$key] = ($value ? 'true' : 'false');
@@ -57,7 +88,8 @@ class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportF
         }
 
         $builder = new JasperPHP();
-        $return = $builder->process(
+
+        $builder->process(
             $this->getReportsPath() . $report->templateName() . '.jasper',
             $outputFile,
             ['pdf'],
@@ -79,6 +111,13 @@ class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportF
         $this->destroyPDF($outputFile);
     }
 
+    /**
+     * Lê o PDF gerado para a saída de conteúdo.
+     *
+     * @param string $file
+     *
+     * @return void
+     */
     public function showPDF($file)
     {
         header('Pragma: public');
@@ -96,6 +135,13 @@ class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportF
         readfile($file);
     }
 
+    /**
+     * Deleta o PDF gerado.
+     *
+     * @param string $file
+     *
+     * @return void
+     */
     public function destroyPDF($file)
     {
         unlink($file);

--- a/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasperXML.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasperXML.php
@@ -6,12 +6,30 @@ require_once 'relatorios/phpjasperxml/class/PHPJasperXML.inc';
 
 class Portabilis_Report_ReportFactoryPHPJasperXML extends Portabilis_Report_ReportFactory
 {
+    /**
+     * Define as configurações dos relatórios.
+     *
+     * @param object $config
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
     public function setSettings($config)
     {
         $this->settings['db'] = $config->app->database;
         $this->settings['logo_file_name'] = $config->report->logo_file_name;
     }
 
+    /**
+     * Carrega o arquivo .jrxml do template.
+     *
+     * @param string $templateName
+     *
+     * @return SimpleXMLElement
+     *
+     * @throws CoreExt_Exception
+     */
     public function loadReportSource($templateName)
     {
         $rootPath = dirname(dirname(dirname(dirname(__FILE__))));
@@ -25,6 +43,14 @@ class Portabilis_Report_ReportFactoryPHPJasperXML extends Portabilis_Report_Repo
         return simplexml_load_file($filePath);
     }
 
+    /**
+     * Retorna o arquivo da logo utilizada nos relatórios.
+     *
+     * @return string
+     *
+     * @throws CoreExt_Exception
+     * @throws Exception
+     */
     public function logoPath()
     {
         if (!$this->settings['logo_file_name']) {
@@ -41,10 +67,21 @@ class Portabilis_Report_ReportFactoryPHPJasperXML extends Portabilis_Report_Repo
         return $filePath;
     }
 
+    /**
+     * Renderiza o relatório.
+     *
+     * @param Portabilis_Report_ReportCore $report
+     * @param array $options
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
     public function dumps($report, $options = [])
     {
-        $defaultOptions = ['add_logo_arg' => true];
-        $options = self::mergeOptions($options, $defaultOptions);
+        $options = self::mergeOptions($options, [
+            'add_logo_arg' => true
+        ]);
 
         if ($options['add_logo_arg']) {
             $report->addArg('logo', $this->logoPath());
@@ -53,6 +90,7 @@ class Portabilis_Report_ReportFactoryPHPJasperXML extends Portabilis_Report_Repo
         $xml = $this->loadReportSource($report->templateName());
 
         $builder = new PHPJasperXML();
+
         $builder->debugsql = false;
         $builder->arrayParameter = $report->args;
 
@@ -66,7 +104,9 @@ class Portabilis_Report_ReportFactoryPHPJasperXML extends Portabilis_Report_Repo
             $this->settings['db']->port
         );
 
-        // I: standard output, D: Download file, F: file
+        // I: standard output
+        // D: Download file
+        // F: file
         $builder->outpage('I');
     }
 }

--- a/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasperXML.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasperXML.php
@@ -1,108 +1,72 @@
 <?php
 
-/**
- * i-Educar - Sistema de gestão escolar
- *
- * Copyright (C) 2006  Prefeitura Municipal de Itajaí
- *                     <ctima@itajai.sc.gov.br>
- *
- * Este programa é software livre; você pode redistribuí-lo e/ou modificá-lo
- * sob os termos da Licença Pública Geral GNU conforme publicada pela Free
- * Software Foundation; tanto a versão 2 da Licença, como (a seu critério)
- * qualquer versão posterior.
- *
- * Este programa é distribuí­do na expectativa de que seja útil, porém, SEM
- * NENHUMA GARANTIA; nem mesmo a garantia implí­cita de COMERCIABILIDADE OU
- * ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral
- * do GNU para mais detalhes.
- *
- * Você deve ter recebido uma cópia da Licença Pública Geral do GNU junto
- * com este programa; se não, escreva para a Free Software Foundation, Inc., no
- * endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.
- *
- * @author    Lucas D'Avila <lucasdavila@portabilis.com.br>
- * @category  i-Educar
- * @license   @@license@@
- * @package   Portabilis
- * @since     Arquivo disponível desde a versão 1.1.0
- * @version   $Id$
- */
-
 require_once 'lib/Portabilis/Report/ReportFactory.php';
-
 require_once 'relatorios/phpjasperxml/class/fpdf/fpdf.php';
 require_once 'relatorios/phpjasperxml/class/PHPJasperXML.inc';
 
-//set_include_path(get_include_path() . PATH_SEPARATOR . 'include/portabilis/libs');
-//require_once 'include/portabilis/libs/XML/RPC2/Client.php';
-
-/**
- * Portabilis_Report_ReportFactoryPHPJasperXML class.
- *
- * @author    Lucas D'Avila <lucasdavila@portabilis.com.br>
- * @category  i-Educar
- * @license   @@license@@
- * @package   Portabilis
- * @since     Classe disponível desde a versão 1.1.0
- * @version   @@package_version@@
- */
-
 class Portabilis_Report_ReportFactoryPHPJasperXML extends Portabilis_Report_ReportFactory
 {
-  function setSettings($config) {
-    $this->settings['db']             = $config->app->database;
-    $this->settings['logo_file_name'] = $config->report->logo_file_name;
-  }
+    public function setSettings($config)
+    {
+        $this->settings['db'] = $config->app->database;
+        $this->settings['logo_file_name'] = $config->report->logo_file_name;
+    }
 
+    public function loadReportSource($templateName)
+    {
+        $rootPath = dirname(dirname(dirname(dirname(__FILE__))));
+        $fileName = "$templateName.jrxml";
+        $filePath = $rootPath . "/modules/Reports/ReportSources/$fileName";
 
-  function loadReportSource($templateName) {
-    $rootPath   = dirname(dirname(dirname(dirname(__FILE__))));
-    $fileName = "$templateName.jrxml";
-    $filePath = $rootPath . "/modules/Reports/ReportSources/$fileName";
+        if (!file_exists($filePath)) {
+            throw new CoreExt_Exception("Report source '$fileName' not found in path '$filePath'");
+        }
 
-    if (! file_exists($filePath))
-      throw new CoreExt_Exception("Report source '$fileName' not found in path '$filePath'");
+        return simplexml_load_file($filePath);
+    }
 
-    return simplexml_load_file($filePath);
-  }
+    public function logoPath()
+    {
+        if (!$this->settings['logo_file_name']) {
+            throw new Exception('No report.logo_file_name defined in configurations!');
+        }
 
+        $rootPath = dirname(dirname(dirname(dirname(__FILE__))));
+        $filePath = $rootPath . "/modules/Reports/ReportLogos/{$this->settings['logo_file_name']}";
 
-  function logoPath() {
-    if (! $this->settings['logo_file_name'])
-      throw new Exception("No report.logo_file_name defined in configurations!");
+        if (!file_exists($filePath)) {
+            throw new CoreExt_Exception("Report logo '{$this->settings['logo_file_name']}' not found in path '$filePath'");
+        }
 
-    $rootPath = dirname(dirname(dirname(dirname(__FILE__))));
-    $filePath = $rootPath . "/modules/Reports/ReportLogos/{$this->settings['logo_file_name']}";
+        return $filePath;
+    }
 
-    if (! file_exists($filePath))
-      throw new CoreExt_Exception("Report logo '{$this->settings['logo_file_name']}' not found in path '$filePath'");
+    public function dumps($report, $options = [])
+    {
+        $defaultOptions = ['add_logo_arg' => true];
+        $options = self::mergeOptions($options, $defaultOptions);
 
-    return $filePath;
-  }
+        if ($options['add_logo_arg']) {
+            $report->addArg('logo', $this->logoPath());
+        }
 
+        $xml = $this->loadReportSource($report->templateName());
 
-  function dumps($report, $options = array()) {
-    $defaultOptions          = array('add_logo_arg' => true);
-    $options                 = self::mergeOptions($options, $defaultOptions);
+        $builder = new PHPJasperXML();
+        $builder->debugsql = false;
+        $builder->arrayParameter = $report->args;
 
-    if ($options['add_logo_arg'])
-      $report->addArg('logo', $this->logoPath());
+        $builder->xml_dismantle($xml);
 
-    $xml                     = $this->loadReportSource($report->templateName());
+        $builder->transferDBtoArray(
+            $this->settings['db']->hostname,
+            $this->settings['db']->username,
+            $this->settings['db']->password,
+            $this->settings['db']->dbname,
+            $this->settings['db']->port
+        );
 
-    $builder                 = new PHPJasperXML();
-    $builder->debugsql       = false;
-    $builder->arrayParameter = $report->args;
-
-    $builder->xml_dismantle($xml);
-
-    $builder->transferDBtoArray($this->settings['db']->hostname,
-                                $this->settings['db']->username,
-                                $this->settings['db']->password,
-                                $this->settings['db']->dbname,
-                                $this->settings['db']->port);
-
-    // I: standard output, D: Download file, F: file
-    $builder->outpage('I');
-  }
+        // I: standard output, D: Download file, F: file
+        $builder->outpage('I');
+    }
 }

--- a/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasperXML.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasperXML.php
@@ -12,8 +12,6 @@ class Portabilis_Report_ReportFactoryPHPJasperXML extends Portabilis_Report_Repo
      * @param object $config
      *
      * @return void
-     *
-     * @throws Exception
      */
     public function setSettings($config)
     {

--- a/ieducar/lib/Portabilis/Report/ReportFactoryRemote.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryRemote.php
@@ -11,8 +11,6 @@ class Portabilis_Report_ReportFactoryRemote extends Portabilis_Report_ReportFact
      * @param object $config
      *
      * @return void
-     *
-     * @throws Exception
      */
     public function setSettings($config)
     {

--- a/ieducar/lib/Portabilis/Report/ReportFactoryRemote.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryRemote.php
@@ -1,11 +1,19 @@
 <?php
 
 require_once 'XML/RPC2/Client.php';
-
 require_once 'lib/Portabilis/Report/ReportFactory.php';
 
 class Portabilis_Report_ReportFactoryRemote extends Portabilis_Report_ReportFactory
 {
+    /**
+     * Define as configurações dos relatórios.
+     *
+     * @param object $config
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
     public function setSettings($config)
     {
         $this->settings['url'] = $config->report->remote_factory->url;
@@ -15,20 +23,28 @@ class Portabilis_Report_ReportFactoryRemote extends Portabilis_Report_ReportFact
         $this->settings['logo_name'] = $config->report->remote_factory->logo_name;
     }
 
+    /**
+     * Renderiza o relatório.
+     *
+     * @param Portabilis_Report_ReportCore $report
+     * @param array $options
+     *
+     * @return mixed
+     *
+     * @throws Exception
+     */
     public function dumps($report, $options = [])
     {
-        $defaultOptions = ['add_logo_name_arg' => true, 'encoding' => 'uncoded'];
-        $options = self::mergeOptions($options, $defaultOptions);
-
-        // logo helper
+        $options = self::mergeOptions($options, [
+            'add_logo_name_arg' => true,
+            'encoding' => 'uncoded'
+        ]);
 
         if ($options['add_logo_name_arg'] and !$this->settings['logo_name']) {
             throw new Exception('The option \'add_logo_name_arg\' is true, but no logo_name defined in configurations!');
         } elseif ($options['add_logo_name_arg']) {
             $report->addArg('logo_name', $this->settings['logo_name']);
         }
-
-        // api call
 
         $client = XML_RPC2_Client::create($this->settings['url']);
 
@@ -40,9 +56,8 @@ class Portabilis_Report_ReportFactoryRemote extends Portabilis_Report_ReportFact
             $args = $report->args
         );
 
-        // report encoding
+        // Esta fábrica retorna o relatório encodado em base64.
 
-        // the remote report factory returns report encoded to base64.
         if ($options['encoding'] == 'base64') {
             $report = $result['report'];
         } elseif ($options['encoding'] == 'uncoded') {

--- a/ieducar/lib/Portabilis/Report/ReportFactoryRemote.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryRemote.php
@@ -1,94 +1,56 @@
 <?php
 
-/**
- * i-Educar - Sistema de gestão escolar
- *
- * Copyright (C) 2006  Prefeitura Municipal de Itajaí
- *                     <ctima@itajai.sc.gov.br>
- *
- * Este programa é software livre; você pode redistribuí-lo e/ou modificá-lo
- * sob os termos da Licença Pública Geral GNU conforme publicada pela Free
- * Software Foundation; tanto a versão 2 da Licença, como (a seu critério)
- * qualquer versão posterior.
- *
- * Este programa é distribuí­do na expectativa de que seja útil, porém, SEM
- * NENHUMA GARANTIA; nem mesmo a garantia implí­cita de COMERCIABILIDADE OU
- * ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral
- * do GNU para mais detalhes.
- *
- * Você deve ter recebido uma cópia da Licença Pública Geral do GNU junto
- * com este programa; se não, escreva para a Free Software Foundation, Inc., no
- * endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.
- *
- * @author    Lucas D'Avila <lucasdavila@portabilis.com.br>
- * @category  i-Educar
- * @license   @@license@@
- * @package   Portabilis
- * @since     Arquivo disponível desde a versão 1.1.0
- * @version   $Id$
- */
-
 require_once 'XML/RPC2/Client.php';
 
 require_once 'lib/Portabilis/Report/ReportFactory.php';
 
-/**
- * Portabilis_Report_ReportFactoryRemote class.
- *
- * @author    Lucas D'Avila <lucasdavila@portabilis.com.br>
- * @category  i-Educar
- * @license   @@license@@
- * @package   Portabilis
- * @since     Classe disponível desde a versão 1.1.0
- * @version   @@package_version@@
- */
-
 class Portabilis_Report_ReportFactoryRemote extends Portabilis_Report_ReportFactory
 {
-    function setSettings($config) {
-      $this->settings['url']             = $config->report->remote_factory->url;
-      $this->settings['app_name']    = $config->report->remote_factory->this_app_name;
-        $this->settings['username']  = $config->report->remote_factory->username;
-      $this->settings['password']  = $config->report->remote_factory->password;
-      $this->settings['logo_name'] = $config->report->remote_factory->logo_name;
+    public function setSettings($config)
+    {
+        $this->settings['url'] = $config->report->remote_factory->url;
+        $this->settings['app_name'] = $config->report->remote_factory->this_app_name;
+        $this->settings['username'] = $config->report->remote_factory->username;
+        $this->settings['password'] = $config->report->remote_factory->password;
+        $this->settings['logo_name'] = $config->report->remote_factory->logo_name;
     }
 
-  function dumps($report, $options = array()) {
-    $defaultOptions = array('add_logo_name_arg' => true, 'encoding' => 'uncoded');
-    $options        = self::mergeOptions($options, $defaultOptions);
+    public function dumps($report, $options = [])
+    {
+        $defaultOptions = ['add_logo_name_arg' => true, 'encoding' => 'uncoded'];
+        $options = self::mergeOptions($options, $defaultOptions);
 
-    // logo helper
+        // logo helper
 
-    if ($options['add_logo_name_arg'] and ! $this->settings['logo_name'])
-        throw new Exception("The option 'add_logo_name_arg' is true, but no logo_name defined in configurations!");
+        if ($options['add_logo_name_arg'] and !$this->settings['logo_name']) {
+            throw new Exception('The option \'add_logo_name_arg\' is true, but no logo_name defined in configurations!');
+        } elseif ($options['add_logo_name_arg']) {
+            $report->addArg('logo_name', $this->settings['logo_name']);
+        }
 
-        elseif ($options['add_logo_name_arg'])
-      $report->addArg('logo_name', $this->settings['logo_name']);
+        // api call
 
+        $client = XML_RPC2_Client::create($this->settings['url']);
 
-    // api call
+        $result = $client->build_report_jasper(
+            $app_name = $this->settings['app_name'],
+            $template_name = $report->templateName(),
+            $username = $this->settings['username'],
+            $password = $this->settings['password'],
+            $args = $report->args
+        );
 
-    $client = XML_RPC2_Client::create($this->settings['url']);
+        // report encoding
 
-    $result = $client->build_report_jasper($app_name      = $this->settings['app_name'],
-                                           $template_name = $report->templateName(),
-                                           $username      = $this->settings['username'],
-                                           $password      = $this->settings['password'],
-                                           $args          = $report->args);
+        // the remote report factory returns report encoded to base64.
+        if ($options['encoding'] == 'base64') {
+            $report = $result['report'];
+        } elseif ($options['encoding'] == 'uncoded') {
+            $report = base64_decode($result['report']);
+        } else {
+            throw new Exception("Encoding {$options['encoding']} not supported!");
+        }
 
-
-    // report encoding
-
-    // the remote report factory returns report encoded to base64.
-    if ($options['encoding'] == 'base64')
-      $report = $result['report'];
-
-    elseif($options['encoding'] == 'uncoded')
-      $report = base64_decode($result['report']);
-
-    else
-      throw new Exception("Encoding {$options['encoding']} not supported!");
-
-    return $report;
-  }
+        return $report;
+    }
 }

--- a/ieducar/modules/Api/Views/ReportController.php
+++ b/ieducar/modules/Api/Views/ReportController.php
@@ -72,14 +72,7 @@ class ReportController extends ApiCoreController
             $boletimReport->addArg('serie', (int)$dadosMatricula['serie_id']);
             $boletimReport->addArg('turma', (int)$dadosMatricula['turma_id']);
             $boletimReport->addArg('situacao_matricula', 10);
-
-            if (CORE_EXT_CONFIGURATION_ENV == 'production') {
-                $boletimReport->addArg('SUBREPORT_DIR', '/sites_media_root/services/reports/jasper/');
-            } elseif ($GLOBALS['coreExt']['Config']->app->database->dbname == 'test' || $GLOBALS['coreExt']['Config']->app->database->dbname == 'desenvolvimento') {
-                $boletimReport->addArg('SUBREPORT_DIR', '/sites_media_root/services-test/reports/jasper/');
-            } else {
-                $boletimReport->addArg('SUBREPORT_DIR', __DIR__ . '/../../Reports/ReportSources/Portabilis/');
-            }
+            $boletimReport->addArg('SUBREPORT_DIR', $GLOBALS['coreExt']['Config']->report->source_path);
 
             $encoding = 'base64';
             $dumpsOptions = ['options' => ['encoding' => $encoding]];
@@ -116,14 +109,7 @@ class ReportController extends ApiCoreController
 
             $boletimProfessorReport->addArg('modelo', $modelo);
             $boletimProfessorReport->addArg('linha', 0);
-
-            if (CORE_EXT_CONFIGURATION_ENV == 'production') {
-                $boletimProfessorReport->addArg('SUBREPORT_DIR', '/sites_media_root/services/reports/jasper/');
-            } elseif ($GLOBALS['coreExt']['Config']->app->database->dbname == 'test' || $GLOBALS['coreExt']['Config']->app->database->dbname == 'desenvolvimento') {
-                $boletimProfessorReport->addArg('SUBREPORT_DIR', '/sites_media_root/services-test/reports/jasper/');
-            } else {
-                $boletimProfessorReport->addArg('SUBREPORT_DIR', __DIR__ . '/../../Reports/ReportSources/Portabilis/');
-            }
+            $boletimProfessorReport->addArg('SUBREPORT_DIR', $GLOBALS['coreExt']['Config']->report->source_path);
 
             $encoding = 'base64';
 

--- a/src/Reports/JsonDataSource.php
+++ b/src/Reports/JsonDataSource.php
@@ -51,28 +51,42 @@ trait JsonDataSource
         $notSchool = empty($this->args['escola']) ? 'true' : 'false';
 
         $sql = "
-        select public.fcn_upper(instituicao.nm_instituicao) as nm_instituicao,
-           public.fcn_upper(instituicao.nm_responsavel) as nm_responsavel,
-           (case when {$notSchool} then 'SECRETARIA DE EDUCAÇÃO' else fcn_upper(view_dados_escola.nome) end) as nm_escola,
-           (case when {$notSchool} then instituicao.ref_idtlog else view_dados_escola.tipo_logradouro end),
-	   (case when {$notSchool} then instituicao.logradouro else view_dados_escola.logradouro end),
-	   (case when {$notSchool} then instituicao.bairro else view_dados_escola.bairro end),
-	   (case when {$notSchool} then instituicao.numero else view_dados_escola.numero end),
-	   (case when {$notSchool} then instituicao.ddd_telefone else view_dados_escola.telefone_ddd end) as fone_ddd,
-	   (case when {$notSchool} then 0 else view_dados_escola.celular_ddd end) as cel_ddd,
-	   (case when {$notSchool} then to_char(instituicao.cep, '99999-999') else to_char(view_dados_escola.cep, '99999-999') end) as cep,
-	   (case when {$notSchool} then to_char(instituicao.telefone, '99999-9999') else view_dados_escola.telefone end) as fone,
-	   (case when {$notSchool} then ' ' else view_dados_escola.celular end) as cel,
-	   (case when {$notSchool} then ' ' else view_dados_escola.email end),
-           instituicao.ref_sigla_uf as uf,
-           instituicao.cidade,
-           view_dados_escola.inep
-      from pmieducar.instituicao
-inner join pmieducar.escola on (instituicao.cod_instituicao = escola.ref_cod_instituicao)
-inner join relatorio.view_dados_escola on (escola.cod_escola = view_dados_escola.cod_escola)
-     where instituicao.cod_instituicao = {$instituicao}
-       and (case when {$notSchool} then true else view_dados_escola.cod_escola = {$escola} end)
-     limit 1
+
+            SELECT 
+                public.fcn_upper(instituicao.nm_instituicao) AS nm_instituicao,
+                public.fcn_upper(instituicao.nm_responsavel) AS nm_responsavel,
+                (CASE WHEN {$notSchool} THEN 'SECRETARIA DE EDUCAÇÃO' ELSE fcn_upper(view_dados_escola.nome) END) AS nm_escola,
+                (CASE WHEN {$notSchool} THEN instituicao.ref_idtlog ELSE view_dados_escola.tipo_logradouro END),
+                (CASE WHEN {$notSchool} THEN instituicao.logradouro ELSE view_dados_escola.logradouro END),
+                (CASE WHEN {$notSchool} THEN instituicao.bairro ELSE view_dados_escola.bairro END),
+                (CASE WHEN {$notSchool} THEN instituicao.numero ELSE view_dados_escola.numero END),
+                (CASE WHEN {$notSchool} THEN instituicao.ddd_telefone ELSE view_dados_escola.telefone_ddd END) AS fone_ddd,
+                (CASE WHEN {$notSchool} THEN 0 ELSE view_dados_escola.celular_ddd END) AS cel_ddd,
+                (CASE WHEN {$notSchool} THEN to_char(instituicao.cep, '99999-999') ELSE to_char(view_dados_escola.cep, '99999-999') END) AS cep,
+                (CASE WHEN {$notSchool} THEN to_char(instituicao.telefone, '99999-9999') ELSE view_dados_escola.telefone END) AS fone,
+                (CASE WHEN {$notSchool} THEN ' ' ELSE view_dados_escola.celular END) AS cel,
+                (CASE WHEN {$notSchool} THEN ' ' ELSE view_dados_escola.email END),
+                instituicao.ref_sigla_uf AS uf,
+                instituicao.cidade,
+                view_dados_escola.inep
+            FROM 
+                pmieducar.instituicao
+            INNER JOIN pmieducar.escola ON TRUE
+                AND (instituicao.cod_instituicao = escola.ref_cod_instituicao)
+            INNER JOIN relatorio.view_dados_escola ON TRUE 
+                AND (escola.cod_escola = view_dados_escola.cod_escola)
+            WHERE TRUE 
+                AND instituicao.cod_instituicao = {$instituicao}
+                AND 
+                (
+                    CASE WHEN {$notSchool} THEN 
+                        TRUE 
+                    ELSE 
+                        view_dados_escola.cod_escola = {$escola} 
+                    END
+                )
+            LIMIT 1
+     
         ";
 
         return $sql;

--- a/src/Reports/JsonDataSource.php
+++ b/src/Reports/JsonDataSource.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace iEducar\Reports;
+
+use Exception;
+use Portabilis_Utils_Database;
+
+trait JsonDataSource
+{
+    /**
+     * @inheritdoc
+     */
+    public function useJson()
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getJsonData()
+    {
+        $queryMainReport = $this->getSqlMainReport();
+        $queryHeaderReport = $this->getSqlHeaderReport();
+
+        return [
+            'main' => Portabilis_Utils_Database::fetchPreparedQuery($queryMainReport),
+            'header' => Portabilis_Utils_Database::fetchPreparedQuery($queryHeaderReport),
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getJsonQuery()
+    {
+        return 'main';
+    }
+
+    /**
+     * Retorna o SQL para buscar os dados que serão adicionados ao cabeçalho.
+     *
+     * @return string
+     *
+     * @throws Exception
+     */
+    public function getSqlHeaderReport()
+    {
+        $instituicao = $this->args['instituicao'] ?: 0;
+        $escola = $this->args['escola'] ?: 0;
+        $notSchool = empty($this->args['escola']) ? 'true' : 'false';
+
+        $sql = "
+        select public.fcn_upper(instituicao.nm_instituicao) as nm_instituicao,
+           public.fcn_upper(instituicao.nm_responsavel) as nm_responsavel,
+           (case when {$notSchool} then 'SECRETARIA DE EDUCAÇÃO' else fcn_upper(view_dados_escola.nome) end) as nm_escola,
+           (case when {$notSchool} then instituicao.ref_idtlog else view_dados_escola.tipo_logradouro end),
+	   (case when {$notSchool} then instituicao.logradouro else view_dados_escola.logradouro end),
+	   (case when {$notSchool} then instituicao.bairro else view_dados_escola.bairro end),
+	   (case when {$notSchool} then instituicao.numero else view_dados_escola.numero end),
+	   (case when {$notSchool} then instituicao.ddd_telefone else view_dados_escola.telefone_ddd end) as fone_ddd,
+	   (case when {$notSchool} then 0 else view_dados_escola.celular_ddd end) as cel_ddd,
+	   (case when {$notSchool} then to_char(instituicao.cep, '99999-999') else to_char(view_dados_escola.cep, '99999-999') end) as cep,
+	   (case when {$notSchool} then to_char(instituicao.telefone, '99999-9999') else view_dados_escola.telefone end) as fone,
+	   (case when {$notSchool} then ' ' else view_dados_escola.celular end) as cel,
+	   (case when {$notSchool} then ' ' else view_dados_escola.email end),
+           instituicao.ref_sigla_uf as uf,
+           instituicao.cidade,
+           view_dados_escola.inep
+      from pmieducar.instituicao
+inner join pmieducar.escola on (instituicao.cod_instituicao = escola.ref_cod_instituicao)
+inner join relatorio.view_dados_escola on (escola.cod_escola = view_dados_escola.cod_escola)
+     where instituicao.cod_instituicao = {$instituicao}
+       and (case when {$notSchool} then true else view_dados_escola.cod_escola = {$escola} end)
+     limit 1
+        ";
+
+        return $sql;
+    }
+
+    /**
+     * Retorna o SQL para buscar os dados do relatório principal.
+     *
+     * @return string
+     *
+     * @throws Exception
+     */
+    public function getSqlMainReport()
+    {
+        throw new Exception('Missing implementation.');
+    }
+}


### PR DESCRIPTION
# Pacote de relatórios

Com o crescimento da comunidade [i-Educar](https://ieducar.org/), adesões de novos municípios utilizando a versão community e o comprometimento da [Portabilis](https://www.portabilis.com.br/) com a comunidade, este patch visa preparar o [i-Educar](https://ieducar.org/) para receber o pacote de relatórios desenvolvidos pela [Portabilis](https://www.portabilis.com.br/) que serão liberados para a comunidade de maneira open source.

## Relatórios atuais

Atualmente, o pacote de relatórios apresentam alguns erros na emissão. Desta forma, estes relatórios serão removidos em prol do novo e mais atualizado pacote que irá conter mais de 40 relatórios.

Estes relatórios continuarão existindo neste novo pacote, porém foram atualizados a fim de utilizar uma arquitetura e tecnologia que melhor se adequa aos novos padrões adotados para o i-Educar.

## Problemas atuais e motivação

Atualmente, todas as regras de negócio/aplicação estão contidas em enormes queries dentro dos arquivos `.jrxml`. Sempre que uma regra de negócio é modificada, alterações na query devem ser efetuadas em todos os relatórios que utilizam a regra tornando a manutenção onerosa. 

O intuito é utilizar JSON como data source permitindo assim remover estas queries de dentro dos arquivos `.jrxml` e movendo-as para a aplicação. Isto permitirá usar o JasperReports apenas como camada de visualização e evitar duplicar a regra de negócio.

Também será possível versionar apenas os arquivos `.jrxml`, pois os arquivos `.jasper` serão compilados apenas no servidor que irá executar a renderização.

### Softwares desatualizados

Atualmente os relatórios atuais do repositório [i-educar-reports-package](https://github.com/portabilis/i-educar-reports-package) foram construídos utilizando o iReport versão `4.7.0`, porém conforme anúncio do seu [website](https://community.jaspersoft.com/project/ireport-designer) o iReport teve seu suporte encerrado em 31 de dezembro de 2015 e o [JasperStudio](https://community.jaspersoft.com/project/jaspersoft-studio) é o _official design client for JasperReports_ desde a versão `5.5.0`. 

O JasperStudio (IDE para construir os relatórios) se encontra na versão `6.6.0` que é a mesma versão do JasperReports (aplicação Java que gera os relatórios).

### Atualização do pacote JasperPHP

O pacote [portabilis/jasperphp](https://packagist.org/packages/portabilis/jasperphp) versão `1.2.0` foi removido em prol do pacote [cossou/jasperphp](https://packagist.org/packages/cossou/jasperphp) versão `2.7`. 

Esta atualização permitirá o uso do [JasperStarter](http://jasperstarter.cenote.de/) versão `3`, utilizando o [JasperReports](https://community.jaspersoft.com/project/jasperreports-library) versão `6`.

### Modificações a nível técnico (código fonte)

Arquitetura, tecnologia e bibliotecas foram atualizados para utilizar versões atuais e estáveis.

#### Classes modificadas

As classes `Portabilis_Report_ReportCore` e `Portabilis_Report_ReportFactory` agora são classes abstratas. 

#### Como migrar os relatórios criados com base no pacote atual

Na classe [ReportCore](https://github.com/portabilis/i-educar-portabilis/blob/7cf4f8f96a23af2031fbfdf8a338111359cc9119/ieducar/lib/Portabilis/Report/ReportCore.php) foram adicionados os métodos `useJson()`, `getJsonQuery()` e `getJsonData()`.

https://github.com/portabilis/i-educar/blob/reports/ieducar/lib/Portabilis/Report/ReportCore.php#L150-L180

Por default:
- `useJson()` irá retornar `false`.
- `getJsonQuery()` retornará uma `string` vazia.
- `getJsonData()` irá retornar um `array` vazio.

Não alterando estes métodos, o i-Educar permanecerá com o comportamento atual, renderizando relatórios baseados em queries dentro dos arquivos `.jrxml`.

Para modificar o comportamento do relatório e fazer o mesmo utilizar JSON como data source, deve-se:

- Sobrescrever o método `useJson()` para retornar `true`.
- Usar o método `getJsonQuery()` para retornar a chave onde se encontra os **dados para o relatório principal**.
  - No caso do JSON `{ "data": [..] }` deverá ser retornado `data`.
  - No caso do JSON `{ "data": { "main": [..] } }` deverá ser retornado `data.main`.
- Sobrescrever o método `getJsonData()` para retornar um `array` com os dados que serão utilizados pelo relatório principal e seu sub-relatório.
```json
{
    "data": {
        "main": [
            { "id": 1, "name": "Eder Soares" },
            { "id": 2, "name": "Amiguinho do Eder Soares" }
        ],
        "header": {
            "school": {
                "name": "Ulbra"
            }
        }
    }
}
```

#### Passar o data source para o sub-relatório

Assim como a conexão com o banco de dados era passada do relatório principal para o sub-relatório na estrutura anterior, agora será necessário passar o arquivo JSON como parâmetro para o sub-relatório.

O relatório principal, quando utilizando JSON como data source, recebe o parâmetro `source` com a localização do arquivo JSON utilizado como data source. Este arquivo é criado e apagado automaticamente. Adicionar ao relatório principal:

```xml
<parameter name="source" class="java.lang.String"/>
```

Deverá ser adicionado ao relatório principal na tag `subreport` o `subreportParameter` chamado `source` que receberá o parâmetro `source` do relatório principal.
```xml
<subreportParameter name="source">
    <subreportParameterExpression><![CDATA[$P{source}]]></subreportParameterExpression>
</subreportParameter>
```

E no sub-relatório deverá ser acrescentado:

```xml
<parameter name="source" class="java.lang.String"/>
<parameter name="net.sf.jasperreports.json.source" class="java.lang.String">
    <defaultValueExpression><![CDATA[$P{source}]]></defaultValueExpression>
</parameter>
<queryString language="json">
    <![CDATA[header]]>
</queryString>
```

## Melhorias e evolução

A partir desta atualização poderemos avançar mais alguns passos e construir mais soluções para o i-Educar.

- Utilizar softwares atualizados para o design dos relatórios.
- Não "parar no tempo" com dependências, softwares e metodologias.
- Possibilitar o desacoplamento de serviços externos (geração de PDFs) da aplicação.
- Criar futuramente um serviço em PHP ou qualquer outra linguagem, que receba uma requisição HTTP e retorne o PDF gerado.
  - Poderemos utilizar uma solução como [AWS Lambda](https://aws.amazon.com/pt/lambda/) para a geração dos PDFs.
  - Será possível testar mais facilmente outros softwares geradores de PDF como [WkHtmlToPdf](https://github.com/wkhtmltopdf/wkhtmltopdf), [MPDF](https://github.com/mpdf/mpdf), [DOMPDF](http://dompdf.github.io/) entre outros em outras linguagens.
  - Criar uma feature onde o suporte ou o cliente possa customizar/criar seu relatório utilizando um construtor de templates como [GrapesJS](https://grapesjs.com/) e então usar uma biblioteca que converte HTML para PDF.