### PR TITLE
Melhor instalação de dependências

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,11 @@ um pacote de mais de 40 relatórios funcionais.
 ### Instalando outras dependências
 
 O i-Educar usa o [Composer](https://getcomposer.org/) para gerenciar suas
-dependências. O Composer já é executado automaticamente para quem utilizar
-docker-compose, basta executar o comando `docker-compose up`.
+dependências. Para instalar, execute o comando:
+
+```bash
+docker run -it -v $(pwd):/app composer install --ignore-platform-reqs
+```
 
 Caso queira adicionar novas dependências ao projeto ou rodar algum outro
 comando do composer, execute da seguinte forma na raiz do projeto:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,7 @@ services:
     links:
       - postgres_95
     container_name: ieducar_1604
-  composer:
-    image: "composer"
-    volumes:
-      - ./:/app
-    command: install --ignore-platform-reqs
+
   postgres_95:
     volumes:
       - /var/lib/postgresql/data


### PR DESCRIPTION
Seguindo os passos do readme, sempre que o comando para rodar as migrations é executado, o Composer ainda não terminou de instalar as dependências e quem está rodando os comandos não consegue identificar o status atual da instalação devido o log não ser exibido.

Este pull request remove o serviço `composer` do `docker-compose.yml` e adiciona ao readme o comando para ser executado manualmente na sequencia correta.