### PR TITLE
Test/remove skip locale test

### DIFF
--- a/docker/ieducar_1604/Dockerfile
+++ b/docker/ieducar_1604/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get -y update \
         gcc \
         zlib1g-dev \
         openjdk-8-jre \
+        language-pack-pt \
     && apt-get clean \
     && apt-get purge --auto-remove -y \
     && rm -rf /var/lib/apt/lists/*

--- a/ieducar/tests/Unit/CoreExt/LocaleTest.php
+++ b/ieducar/tests/Unit/CoreExt/LocaleTest.php
@@ -12,6 +12,12 @@ class CoreExt_LocaleTest extends UnitBaseTest
     $this->_instance->resetLocale();
   }
 
+  protected function tearDown()
+  {
+      $this->_instance = CoreExt_Locale::getInstance();
+      $this->_instance->resetLocale();
+  }
+
   public function testFloatComOLocaleDefault()
   {
     $float = 3.5;

--- a/ieducar/tests/Unit/CoreExt/LocaleTest.php
+++ b/ieducar/tests/Unit/CoreExt/LocaleTest.php
@@ -1,47 +1,7 @@
 <?php
 
-/**
- * i-Educar - Sistema de gestão escolar
- *
- * Copyright (C) 2006  Prefeitura Municipal de Itajaí
- *                     <ctima@itajai.sc.gov.br>
- *
- * Este programa é software livre; você pode redistribuí-lo e/ou modificá-lo
- * sob os termos da Licença Pública Geral GNU conforme publicada pela Free
- * Software Foundation; tanto a versão 2 da Licença, como (a seu critério)
- * qualquer versão posterior.
- *
- * Este programa é distribuí­do na expectativa de que seja útil, porém, SEM
- * NENHUMA GARANTIA; nem mesmo a garantia implí­cita de COMERCIABILIDADE OU
- * ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral
- * do GNU para mais detalhes.
- *
- * Você deve ter recebido uma cópia da Licença Pública Geral do GNU junto
- * com este programa; se não, escreva para a Free Software Foundation, Inc., no
- * endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.
- *
- * @author      Eriksen Costa Paixão <eriksen.paixao_bs@cobra.com.br>
- * @category    i-Educar
- * @license     @@license@@
- * @package     CoreExt_Locale
- * @subpackage  UnitTests
- * @since       Arquivo disponível desde a versão 1.1.0
- * @version     $Id: /ieducar/branches/1.1.0-avaliacao/ieducar/tests/unit/CoreExt/EnumTest.php 770 2009-11-24T18:31:56.633773Z eriksen  $
- */
-
 require_once 'CoreExt/Locale.php';
 
-/**
- * CoreExt_LocaleTest class.
- *
- * @author      Eriksen Costa Paixão <eriksen.paixao_bs@cobra.com.br>
- * @category    i-Educar
- * @license     @@license@@
- * @package     CoreExt_Locale
- * @subpackage  UnitTests
- * @since       Classe disponível desde a versão 1.1.0
- * @version     @@package_version@@
- */
 class CoreExt_LocaleTest extends UnitBaseTest
 {
   protected $_instance = NULL;

--- a/ieducar/tests/Unit/CoreExt/LocaleTest.php
+++ b/ieducar/tests/Unit/CoreExt/LocaleTest.php
@@ -4,58 +4,58 @@ require_once 'CoreExt/Locale.php';
 
 class CoreExt_LocaleTest extends UnitBaseTest
 {
-  protected $_instance = NULL;
+    protected $_instance = null;
 
-  protected function setUp()
-  {
-    $this->_instance = CoreExt_Locale::getInstance();
-    $this->_instance->resetLocale();
-  }
-
-  protected function tearDown()
-  {
-      $this->_instance = CoreExt_Locale::getInstance();
-      $this->_instance->resetLocale();
-  }
-
-  public function testFloatComOLocaleDefault()
-  {
-    $float = 3.5;
-    $this->assertEquals('3.5', (string) $float);
-  }
-
-  public function testFloatComUmLocaleQueUsaVirgulaParaSepararDecimais()
-  {
-    $this->_instance->setCulture('pt_BR')->setLocale();
-    if (strpos($this->_instance->actualCulture['LC_NUMERIC'], 'pt_BR') === false) {
-        $this->markTestSkipped('Locale pt_BR não instalado.');
+    protected function setUp()
+    {
+        $this->_instance = CoreExt_Locale::getInstance();
+        $this->_instance->resetLocale();
     }
-    $float = 3.5;
-    $this->assertEquals('3,5', (string) $float);
-  }
 
-  public function testResetDeLocale()
-  {
-    $this->_instance->setLocale('pt_BR');
-    if (strpos($this->_instance->actualCulture['LC_NUMERIC'], 'pt_BR') === false) {
-        $this->markTestSkipped('Locale pt_BR não instalado.');
+    protected function tearDown()
+    {
+        $this->_instance = CoreExt_Locale::getInstance();
+        $this->_instance->resetLocale();
     }
-    $float = 3.5;
-    $this->assertEquals('3,5', (string) $float);
-    $this->_instance->resetLocale();
-    $this->assertEquals('3.5', (string) $float);
-  }
 
-  public function testInformacaoDeNumericosDoLocale()
-  {
-    $cultureInfo = $this->_instance->getCultureInfo();
-    $this->assertEquals(18, count($cultureInfo));
-    $this->assertEquals('.', $this->_instance->getCultureInfo('decimal_point'));
-
-    $this->_instance->setLocale('pt_BR');
-    if (strpos($this->_instance->actualCulture['LC_NUMERIC'], 'pt_BR') === false) {
-        $this->markTestSkipped('Locale pt_BR não instalado.');
+    public function testFloatComOLocaleDefault()
+    {
+        $float = 3.5;
+        $this->assertEquals('3.5', (string) $float);
     }
-    $this->assertEquals(',', $this->_instance->getCultureInfo('decimal_point'));
-  }
+
+    public function testFloatComUmLocaleQueUsaVirgulaParaSepararDecimais()
+    {
+        $this->_instance->setCulture('pt_BR')->setLocale();
+        if (strpos($this->_instance->actualCulture['LC_NUMERIC'], 'pt_BR') === false) {
+            $this->markTestSkipped('Locale pt_BR não instalado.');
+        }
+        $float = 3.5;
+        $this->assertEquals('3,5', (string) $float);
+    }
+
+    public function testResetDeLocale()
+    {
+        $this->_instance->setLocale('pt_BR');
+        if (strpos($this->_instance->actualCulture['LC_NUMERIC'], 'pt_BR') === false) {
+            $this->markTestSkipped('Locale pt_BR não instalado.');
+        }
+        $float = 3.5;
+        $this->assertEquals('3,5', (string) $float);
+        $this->_instance->resetLocale();
+        $this->assertEquals('3.5', (string) $float);
+    }
+
+    public function testInformacaoDeNumericosDoLocale()
+    {
+        $cultureInfo = $this->_instance->getCultureInfo();
+        $this->assertEquals(18, count($cultureInfo));
+        $this->assertEquals('.', $this->_instance->getCultureInfo('decimal_point'));
+
+        $this->_instance->setLocale('pt_BR');
+        if (strpos($this->_instance->actualCulture['LC_NUMERIC'], 'pt_BR') === false) {
+            $this->markTestSkipped('Locale pt_BR não instalado.');
+        }
+        $this->assertEquals(',', $this->_instance->getCultureInfo('decimal_point'));
+    }
 }

--- a/ieducar/tests/Unit/CoreExt/LocaleTest.php
+++ b/ieducar/tests/Unit/CoreExt/LocaleTest.php
@@ -61,7 +61,7 @@ class CoreExt_LocaleTest extends UnitBaseTest
   public function testFloatComUmLocaleQueUsaVirgulaParaSepararDecimais()
   {
     $this->_instance->setCulture('pt_BR')->setLocale();
-    if ($this->_instance->actualCulture['LC_ALL'] == 'C') {
+    if (strpos($this->_instance->actualCulture['LC_NUMERIC'], 'pt_BR') === false) {
         $this->markTestSkipped('Locale pt_BR não instalado.');
     }
     $float = 3.5;
@@ -71,7 +71,7 @@ class CoreExt_LocaleTest extends UnitBaseTest
   public function testResetDeLocale()
   {
     $this->_instance->setLocale('pt_BR');
-    if ($this->_instance->actualCulture['LC_ALL'] == 'C') {
+    if (strpos($this->_instance->actualCulture['LC_NUMERIC'], 'pt_BR') === false) {
         $this->markTestSkipped('Locale pt_BR não instalado.');
     }
     $float = 3.5;
@@ -87,7 +87,7 @@ class CoreExt_LocaleTest extends UnitBaseTest
     $this->assertEquals('.', $this->_instance->getCultureInfo('decimal_point'));
 
     $this->_instance->setLocale('pt_BR');
-    if ($this->_instance->actualCulture['LC_ALL'] == 'C') {
+    if (strpos($this->_instance->actualCulture['LC_NUMERIC'], 'pt_BR') === false) {
         $this->markTestSkipped('Locale pt_BR não instalado.');
     }
     $this->assertEquals(',', $this->_instance->getCultureInfo('decimal_point'));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Descrição

A aplicação precisava de locale pt_BR para correto tratamento de números utilizando a função setlocale. Foi instalado o pacote no Dockerfile e modificado os testes para apenas serem marcados como skipped quando LC_NUMERIC não for alterado (que é a proposta deste teste alterá-lo).

O teste estava também alterando o locale da aplicação e não estava voltando com o locale default do sistema, isto pode impactar em outras partes, para sanar foi implementado método tearDown.

De quebra foi aplicado PSR2 na classe alterada.

## Contexto e motivação
Resolve #410

## Tipos de alterações
<!--- Que tipo de mudanças seu código apresenta? -->
<!--- Remova todas as linhas que não foram aplicadas. -->
- ✅ Bug fix (Não quebra outras funcionalidades)

## Checklist:
<!--- Verifique todos os pontos. -->
<!--- Novamente, remova todas as linhas que não foram aplicadas. -->
<!--- Pull Requests que não atenderem todos os [REQUIRED] provavelmente não serão aceitos -->

- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**
- ✅ Criei testes automatizados que cobrem minhas alterações.
