### PR TITLE
Remove PostgreSQL client do Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ matrix:
         - 7.2
       addons:
         postgresql: 9.5
-        apt:
-          packages:
-            - postgresql-9.5
       env:
         - APP_ENV=testing
         - DB_CONNECTION=pgsql


### PR DESCRIPTION
Com variáveis de ambiente, não é mais necessária a utilização do PostgreSQL client.

## Contexto e motivação

Remover ferramenta não utilizada do CI.

- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**
