### PR TITLE
Rodar o i-Educar utilizando o servidor interno do Laravel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 /database/backups
 /database/data
 /database/migrations/extras
-/legacy
-/public/intranet
-/public/module
 /public/modules
 /vendor
 /ieducar-*

--- a/app/Console/Commands/LegacyLinkCommand.php
+++ b/app/Console/Commands/LegacyLinkCommand.php
@@ -24,12 +24,13 @@ class LegacyLinkCommand extends Command
      * Create a symbol link for $path and show a info message.
      *
      * @param string $path
+     * @param string $target
      *
      * @return void
      */
-    private function createSymbolLink($path)
+    private function createSymbolLink($path, $target = '../')
     {
-        $legacy = '../' . config('legacy.path') . '/' . $path;
+        $legacy = $target . config('legacy.path') . '/' . $path;
         $public = public_path($path);
 
         if (is_link($public)) {
@@ -48,10 +49,26 @@ class LegacyLinkCommand extends Command
      */
     public function handle()
     {
-        $paths = ['intranet', 'module', 'modules'];
+        $links = [
+            '../../' => [
+                'intranet/arquivos',
+                'intranet/downloads',
+                'intranet/fonts',
+                'intranet/fotos',
+                'intranet/imagens',
+                'intranet/scripts',
+                'intranet/static',
+                'intranet/styles',
+            ],
+            '../' => [
+                'modules',
+            ],
+        ];
 
-        foreach ($paths as $path) {
-            $this->createSymbolLink($path);
+        foreach ($links as $target => $paths) {
+            foreach ($paths as $path) {
+                $this->createSymbolLink($path, $target);
+            }
         }
     }
 }

--- a/app/Http/Controllers/LegacyModuleRewriteController.php
+++ b/app/Http/Controllers/LegacyModuleRewriteController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Response;
+
+class LegacyModuleRewriteController extends Controller
+{
+    /**
+     * Rewrite a URL like a web server rewrite rule.
+     *
+     * @param string $module
+     * @param string $path
+     * @param string $resource
+     *
+     * @return Response
+     */
+    public function rewrite($module, $path, $resource)
+    {
+        $filename = base_path("ieducar/intranet/{$path}/{$resource}");
+
+        $contentFile = file_get_contents($filename);
+        $contentType = mime_content_type($filename);
+
+        return new Response($contentFile, Response::HTTP_OK, [
+            'Content-Type' => $contentType
+        ]);
+    }
+}

--- a/ieducar/configuration/ieducar.ini.example
+++ b/ieducar/configuration/ieducar.ini.example
@@ -148,11 +148,13 @@ modules.error.tracker_name = EMAIL
 modules.error.honeybadger_key =
 modules.error.email_recipient =
 
-[development : production]
+[testing : production]
 
-[testing : development]
+[development : testing]
 
 [localhost : development]
+
+[local : localhost]
 
 ; Use seções especificas para adicionar configs que distinguem entre tenants,
 ; Ex.: para o host https://tenant.ieducar.com.br/, pode-se usar esta seção

--- a/ieducar/includes/bootstrap.php
+++ b/ieducar/includes/bootstrap.php
@@ -35,11 +35,12 @@ $coreExt['Config'] = new CoreExt_Config_Ini($configFile, CORE_EXT_CONFIGURATION_
 
 date_default_timezone_set($coreExt['Config']->app->locale->timezone);
 
-$tenantEnv = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : null;
+$tenantEnv = $_SERVER['HTTP_HOST'] ?? null;
+$devEnv = ['development', 'local'];
 
 if ($coreExt['Config']->hasEnviromentSection($tenantEnv)) {
     $coreExt['Config']->changeEnviroment($tenantEnv);
-} else if (!$coreExt['Config']->hasEnviromentSection($tenantEnv) && CORE_EXT_CONFIGURATION_ENV !== "development"){
+} else if (!in_array(CORE_EXT_CONFIGURATION_ENV, $devEnv)){
     $coreExt['Config']->app->ambiente_inexistente = true;
 }
 

--- a/public/intranet/.gitignore
+++ b/public/intranet/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,13 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::redirect('/', 'intranet/index.php');
-Route::any('/module/{uri}', 'LegacyController@module')->where('uri', '.*');
-Route::any('/modules/{uri}', 'LegacyController@modules')->where('uri', '.*');
-Route::any('/intranet/{uri}', 'LegacyController@intranet')->where('uri', '.*');
+Route::redirect('intranet', 'index.php');
+
+Route::any('module/{module}/{path}/{resource}', 'LegacyModuleRewriteController@rewrite')
+    ->where('module', '.*')
+    ->where('path', 'imagens|scripts|styles')
+    ->where('resource', '.*');
+
+Route::any('module/{uri}', 'LegacyController@module')->where('uri', '.*');
+Route::any('modules/{uri}', 'LegacyController@modules')->where('uri', '.*');
+Route::any('intranet/{uri}', 'LegacyController@intranet')->where('uri', '.*');

--- a/server.php
+++ b/server.php
@@ -11,10 +11,14 @@ $uri = urldecode(
     parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
 );
 
+$file = __DIR__ . '/public' . $uri;
+
+$except = ['/', '/intranet', '/intranet/'];
+
 // This file allows us to emulate Apache's "mod_rewrite" functionality from the
 // built-in PHP web server. This provides a convenient way to test a Laravel
 // application without having installed a "real" web server software here.
-if ($uri !== '/' && file_exists(__DIR__.'/public'.$uri)) {
+if (!in_array($uri, $except) && file_exists($file)) {
     return false;
 }
 


### PR DESCRIPTION
Possibilita o uso do servidor interno do Laravel permitindo rodar o i-Educar apenas com o Postgres `9.5` e PHP `>=7.1.3` instalados localmente.

Não será mais necessário utilizar Docker para fazer demonstração ou iniciar o desenvolvimento, porém é aconselhável para garantir maior confiabilidade com a realidade de um serviço na web.

Para executar o i-Educar utilizando o servidor interno, execute o comando `php artisan serve`.

## Descrição

- Altera o comando que cria os links simbólicos para a aplicação legada.
- Adiciona um novo controller para simular as _rewrite rules_ de um servidor web.
- Cria novas rotas.
- Modifica as regras do servidor interno do Laravel.

## Contexto e motivação

Diminuir a barreira de entrada para novos desenvolvedores ou quem queira fazer demonstrações simples do i-Educar.

## Tipos de alterações
- ✅ New feature (Não quebra outras funcionalidades e adiciona funcionalidades)

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**
