### PR TITLE
Atualiza README.me, corrigindo contribuição e código de conduta

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ Acreditamos que o sucesso do projeto depende diretamente da interação clara e
 objetiva entre os membros da Comunidade. Por isso, estamos definindo algumas
 políticas para que estas interações nos ajudem a crescer juntos! Você pode
 consultar algumas destas boas práticas em nosso [código de
-conduta](https://github.com/portabilis/i-educar/blob/master/CODE_OF_CONDUCT.md).
+conduta](https://github.com/portabilis/i-educar/blob/master/code-of-conduct.md).
 
 Além disso, gostamos de meios de comunicação assíncrona, onde não há necessidade de
 respostas em tempo real. Isso facilita a produtividade individual dos
@@ -78,7 +78,7 @@ para ler mais a respeito.
 ## Como contribuir
 
 Contribuições são **super bem vindas**! Se você tem vontade de construir o
-i-Educar junto conosco, veja o nosso [guia de contribuição](./CONTRIBUTING.md)
+i-Educar junto conosco, veja o nosso [guia de contribuição](./contributing.md)
 onde explicamos detalhadamente como trabalhamos e de que formas você pode nos
 ajudar a alcançar nossos objetivos.
 
@@ -258,7 +258,7 @@ encontram em `storage/logs` para determinar suas causas. Não hesite em
 
 O i-Educar possui um pacote de mais de 40 relatórios.
 
-Para instalar o pacote de relatórios visite o repositório do projeto 
+Para instalar o pacote de relatórios visite o repositório do projeto
 [https://github.com/portabilis/i-educar-reports-package](https://github.com/portabilis/i-educar-reports-package)
 e siga as instruções de instalação.
 


### PR DESCRIPTION
Corrige os links para "Guia de contribuição" e "Código de conduta" no README.md que faziam referência a `CONTRIBUTING.md` e `CODE_OF_CONDUCT.md` e agora estão com outro nome `contributing.md` e `code-of-conduct.md`

## Descrição
Alterei os links que referenciavam esses arquivos antigos, colocando seus nomes atuais.

## Contexto e motivação
Corrige o erro 404 que era disparado por não encontrar o arquivo.

## Tipos de alterações
- ✅ Bug fix (Não quebra outras funcionalidades)

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**
- ✅ Criei testes automatizados que cobrem minhas alterações.
