### PR TITLE
Corrige erro ao iniciar sessão no fake controller

### DIFF
--- a/app/Http/Controllers/LegacyFakeAuthController.php
+++ b/app/Http/Controllers/LegacyFakeAuthController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use Throwable;
+
 class LegacyFakeAuthController
 {
     /**
@@ -11,8 +13,10 @@ class LegacyFakeAuthController
      */
     public function doFakeLogin()
     {
-        if (empty($_SESSION)) {
+        try {
             session_start();
+        } catch (Throwable $throwable) {
+
         }
 
         $_SESSION['itj_controle'] = 'logado';
@@ -32,8 +36,10 @@ class LegacyFakeAuthController
      */
     public function doFakeLogout()
     {
-        if (empty($_SESSION)) {
+        try {
             session_start();
+        } catch (Throwable $throwable) {
+
         }
 
         $_SESSION = [];


### PR DESCRIPTION
## Descrição
Após PR #482 foi identificado que erros poderiam ser gerados quando o Laravel Dusk é utilizado nos testes de browser e simula o login em uma request.

## Tipos de alterações
- ✅ Bug fix (Não quebra outras funcionalidades)

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**
