### PR TITLE
Permite desativar a supressão de erros

### DIFF
--- a/app/Http/Controllers/LegacyController.php
+++ b/app/Http/Controllers/LegacyController.php
@@ -55,6 +55,10 @@ class LegacyController extends Controller
      */
     private function configureErrorsAndExceptions()
     {
+        if (config('legacy.display_errors')) {
+            return;
+        }
+
         ini_set('display_errors', 'off');
 
         error_reporting(0);


### PR DESCRIPTION
## Descrição

Qualquer rota que passa pelo `LegacyController` tem seus erros desativados devido ao código legado gerar notices e warnings.

Este PR irá permitir que ao definir `true` para `LEGACY_DISPLAY_ERRORS`, os erros sejam exibidos.

Isso irá ajudar na refatoração e melhoria da qualidade do código.

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**