### PR TITLE
Nginx upstream

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,9 @@ services:
       - php
     ports:
       - 80
-    working_dir: /application
+    working_dir: /var/www/ieducar
     volumes:
-      - ./:/application
+      - ./:/var/www/ieducar
 
   php:
     container_name: ieducar-php
@@ -26,9 +26,9 @@ services:
       XDEBUG_REMOTE_PORT: 9000
       XDEBUG_REMOTE_ENABLE: 0
       XDEBUG_AUTOSTART: 0
-    working_dir: /application
+    working_dir: /var/www/ieducar
     volumes:
-      - ./:/application
+      - ./:/var/www/ieducar
 
   postgres:
     container_name: ieducar-postgres

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -5,3 +5,4 @@ MAINTAINER Eder Soares
 RUN apt-get update -y
 
 COPY default.conf /etc/nginx/conf.d/default.conf
+COPY upstream.conf /etc/nginx/conf.d/upstream.conf

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,10 +1,14 @@
 server {
 
+    listen 80;
+
+    server_name default_server;
+
+    root /var/www/ieducar/public;
     index index.php index.html;
-    server_name _;
+
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;
-    root /var/www/ieducar/public;
 
     location ~ ^/intranet/?$ {
         rewrite ^.*$ /intranet/index.php redirect;

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -32,7 +32,7 @@ server {
 
     location ~ \.php {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass php:9000;
+        fastcgi_pass php-fpm;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -27,17 +27,10 @@ server {
     }
 
     location ~ ^(/intranet.*\.php|/modules.*\.php|/module/) {
-        try_files /index.php =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass php:9000;
-        fastcgi_index index.php;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_param PATH_INFO $fastcgi_path_info;
+        rewrite ^(.*)$ /index.php$1;
     }
 
     location ~ \.php {
-        try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass php:9000;
         fastcgi_index index.php;

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -4,7 +4,7 @@ server {
     server_name _;
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;
-    root /application/public;
+    root /var/www/ieducar/public;
 
     location ~ ^/intranet/?$ {
         rewrite ^.*$ /intranet/index.php redirect;

--- a/docker/nginx/upstream.conf
+++ b/docker/nginx/upstream.conf
@@ -1,0 +1,3 @@
+upstream php-fpm {
+    server php:9000;
+}

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -44,7 +44,7 @@ RUN docker-php-ext-install zip
 
 RUN apt-get install -y unzip
 
-RUN ln -s /application/artisan /usr/local/bin/artisan
+RUN ln -s /var/www/ieducar/artisan /usr/local/bin/artisan
 
 RUN mkdir -p /usr/share/man/man7
 RUN apt-get install -y postgresql-client

--- a/ieducar/configuration/ieducar.ini.example
+++ b/ieducar/configuration/ieducar.ini.example
@@ -136,7 +136,7 @@ report.show_error_details = true
 report.default_factory = Portabilis_Report_ReportFactoryPHPJasper
 
 ; Define o diretório dos arquivos fontes dos relatórios
-report.source_path = /application/ieducar/modules/Reports/ReportSources/
+report.source_path = /var/www/ieducar/ieducar/modules/Reports/ReportSources/
 
 ; Configurações usadas pelo modulo de tratamento de erros ocorridos na aplicação.
 modules.error.link_to_support = https://forum.ieducar.org/


### PR DESCRIPTION
## Descrição

Desacopla a configuração do Nginx para escolher o upstream do PHP.

## Contexto e motivação

A instalação do i-Educar em servidor por muitas vezes ainda é dificultosa para quem não tem muita familiaridade com a configuração de servidores web.

### Instalação em servidor 

A intenção deste PR é facilitar a instalação permitindo que o serviço PHP executado possa ser configurado a parte. Dessa forma basta copiar os arquivos `default.conf` e `upstream.conf`  para a pasta do Nginx. Apenas o arquivo `upstream.conf`, com 3 linhas apenas, que precisa ser alterado.

A instalação em um servidor é resumida aos comandos:

```
git clone https://github.com/portabilis/i-educar.git /var/www/ieducar

cd /var/www/ieducar

cp docker/nginx/default.conf /etc/nginx/conf.d/default.conf
cp docker/nginx/upstream.conf /etc/nginx/conf.d/upstream.conf

composer new-install
```

Basta alterar o arquivo `upstream.conf` para algo similar a:

```
upstream php-fpm {
    server unix:/var/run/php/php7.2-fpm.sock;
}
```

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**