### PR TITLE
Move testes para a pasta correta

### DIFF
--- a/tests/Unit/Services/CacheManagerTest.php
+++ b/tests/Unit/Services/CacheManagerTest.php
@@ -2,14 +2,7 @@
 
 namespace Tests\Unit\Services;
 
-use App\Models\Menu;
-use App\Models\Submenu;
-use App\Models\User;
 use App\Services\CacheManager;
-use App\Services\MenuService;
-use iEducar\Support\Repositories\MenuRepository;
-use iEducar\Support\Repositories\UserRepository;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Cache;
 use Tests\TestCase;
 
@@ -18,6 +11,7 @@ class CacheManagerTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+
         Cache::swap(new CacheManager(app()));
         Cache::flush();
     }

--- a/tests/Unit/Services/CacheManagerTest.php
+++ b/tests/Unit/Services/CacheManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Service;
+namespace Tests\Unit\Services;
 
 use App\Models\Menu;
 use App\Models\Submenu;

--- a/tests/Unit/Services/MenuServiceTest.php
+++ b/tests/Unit/Services/MenuServiceTest.php
@@ -7,7 +7,6 @@ use App\Models\Submenu;
 use App\Models\User;
 use App\Services\MenuService;
 use iEducar\Support\Repositories\MenuRepository;
-use iEducar\Support\Repositories\UserRepository;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 
@@ -40,7 +39,7 @@ class MenuServiceTest extends TestCase
         $result = $this->service->getByUser($user);
         $this->assertEmpty($result);
     }
-    
+
     public function testCommonUserShouldReturnByPermission()
     {
         $user = factory(User::class)->create();
@@ -67,5 +66,4 @@ class MenuServiceTest extends TestCase
         $this->assertTrue($result->contains($activeSubmenu->menu));
         $this->assertFalse($result->contains($inactiveSubmenu->menu));
     }
-
 }

--- a/tests/Unit/Services/MenuServiceTest.php
+++ b/tests/Unit/Services/MenuServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Service;
+namespace Tests\Unit\Services;
 
 use App\Models\Menu;
 use App\Models\Submenu;


### PR DESCRIPTION
## Descrição
Os testes de serviços estavam na pasta errada. Move para a pasta correta e limpa as classes.

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**