### PR TITLE
[2.2] Remove requires do arquivo `bootstrap.php`

### DIFF
--- a/ieducar/includes/bootstrap.php
+++ b/ieducar/includes/bootstrap.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 $app = require_once __DIR__ . '/../../bootstrap/app.php';
 
@@ -31,7 +32,7 @@ $devEnv = ['development', 'local', 'testing', 'dusk'];
 if ($coreExt['Config']->hasEnviromentSection($tenantEnv)) {
     $coreExt['Config']->changeEnviroment($tenantEnv);
 } else if (!in_array($env, $devEnv)){
-    $coreExt['Config']->app->ambiente_inexistente = true;
+    throw new NotFoundHttpException();
 }
 
 chdir(base_path('ieducar/intranet'));

--- a/ieducar/intranet/clsConfigItajai.inc.php
+++ b/ieducar/intranet/clsConfigItajai.inc.php
@@ -79,8 +79,9 @@ class clsConfig
    */
   private function setArrayConfig()
   {
+    require_once __DIR__ . '/../includes/bootstrap.php';
+    
     global $coreExt;
-    $config = $coreExt['Config'];
 
     $config = $coreExt['Config']->app;
 

--- a/ieducar/intranet/download.php
+++ b/ieducar/intranet/download.php
@@ -1,5 +1,4 @@
 <?php
 
-require_once 'includes/bootstrap.php';
 require_once 'includes/download.php';   // Faz uso de $_GET['filename']
 exit();

--- a/ieducar/intranet/educar_instituicao_cad.php
+++ b/ieducar/intranet/educar_instituicao_cad.php
@@ -5,7 +5,6 @@ require_once 'include/clsCadastro.inc.php';
 require_once 'include/clsBanco.inc.php';
 require_once 'include/pmieducar/geral.inc.php';
 require_once 'include/Geral.inc.php';
-require_once 'includes/bootstrap.php';
 require_once 'Portabilis/Date/Utils.php';
 require_once 'Portabilis/Currency/Utils.php';
 require_once 'include/modules/clsModulesAuditoriaGeral.inc.php';

--- a/ieducar/intranet/include/Geral.inc.php
+++ b/ieducar/intranet/include/Geral.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once 'includes/bootstrap.php';
 require_once 'include/pmieducar/clsPermissoes.inc.php';
 require_once 'include/pessoa/clsPessoa_.inc.php';
 require_once 'include/pessoa/clsPessoaFj.inc.php';

--- a/ieducar/intranet/include/clsBanco.inc.php
+++ b/ieducar/intranet/include/clsBanco.inc.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Support\Facades\DB;
 
-require_once 'includes/bootstrap.php';
 require_once 'include/clsBancoPgSql.inc.php';
 
 class clsBanco extends clsBancoSQL_

--- a/ieducar/intranet/include/clsBase.inc.php
+++ b/ieducar/intranet/include/clsBase.inc.php
@@ -5,7 +5,6 @@ use iEducar\Support\Navigation\TopMenu;
 use Illuminate\Support\Facades\View;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
-require_once __DIR__ . '/../../includes/bootstrap.php';
 require_once 'clsConfigItajai.inc.php';
 require_once 'include/clsBanco.inc.php';
 require_once 'include/clsControlador.inc.php';
@@ -18,10 +17,6 @@ require_once 'Portabilis/Utils/User.php';
 require_once 'Portabilis/String/Utils.php';
 require_once 'Portabilis/Assets/Version.php';
 require_once 'include/pessoa/clsCadastroFisicaFoto.inc.php';
-
-if ($GLOBALS['coreExt']['Config']->app->ambiente_inexistente) {
-    header('Location: /404.html');
-}
 
 class clsBase extends clsConfig
 {

--- a/ieducar/intranet/include/clsControlador.inc.php
+++ b/ieducar/intranet/include/clsControlador.inc.php
@@ -178,7 +178,7 @@ class clsControlador
     protected function renderLoginPage()
     {
         $this->destroyLoginSession();
-        require_once __DIR__ . '/../../includes/bootstrap.php';
+
         $parceiro = $GLOBALS['coreExt']['Config']->app->template->layout;
         $templateName = (trim($parceiro) == '' ? 'templates/nvp_htmlloginintranet.tpl' : 'templates/' . trim($parceiro));
         $templateFile = fopen($templateName, 'r');

--- a/ieducar/intranet/include/pmicontrolesis/geral.inc.php
+++ b/ieducar/intranet/include/pmicontrolesis/geral.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once 'includes/bootstrap.php';
 require_once 'include/clsBanco.inc.php';
 require_once 'include/Geral.inc.php';
 require_once 'include/pmicontrolesis/clsMenuSuspenso.inc.php';

--- a/ieducar/intranet/include/pmieducar/geral.inc.php
+++ b/ieducar/intranet/include/pmieducar/geral.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once 'includes/bootstrap.php';
 require_once 'include/clsBanco.inc.php';
 require_once 'include/Geral.inc.php';
 require_once 'include/pmieducar/clsPermissoes.inc.php';

--- a/ieducar/intranet/include/portal/geral.inc.php
+++ b/ieducar/intranet/include/portal/geral.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once 'includes/bootstrap.php';
 require_once 'include/clsBanco.inc.php';
 require_once 'include/portal/clsPortalAcesso.inc.php';
 require_once 'include/portal/clsPortalFuncionario.inc.php';

--- a/ieducar/intranet/include/public/geral.inc.php
+++ b/ieducar/intranet/include/public/geral.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once 'includes/bootstrap.php';
 require_once 'include/clsBanco.inc.php';
 require_once 'include/Geral.inc.php';
 require_once 'include/public/clsPublicBairro.inc.php';

--- a/ieducar/intranet/include/urbano/geral.inc.php
+++ b/ieducar/intranet/include/urbano/geral.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once 'includes/bootstrap.php';
 require_once 'include/clsBanco.inc.php';
 require_once 'include/Geral.inc.php';
 require_once 'include/urbano/clsUrbanoCepLogradouro.inc.php';

--- a/ieducar/intranet/s3_config.php
+++ b/ieducar/intranet/s3_config.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/../includes/bootstrap.php';
-
 $bucket = $GLOBALS['coreExt']['Config']->app->aws->bucketname;
 $directory = $GLOBALS['coreExt']['Config']->app->database->dbname . '/';
 $key = $GLOBALS['coreExt']['Config']->app->aws->awsacesskey;

--- a/ieducar/intranet/suspenso.php
+++ b/ieducar/intranet/suspenso.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once __DIR__ . '/../includes/bootstrap.php';
 require_once 'include/pmieducar/clsPmieducarConfiguracoesGerais.inc.php';
 
 $configuracoes = new clsPmieducarConfiguracoesGerais();

--- a/ieducar/intranet/xml_acervo_geral.php
+++ b/ieducar/intranet/xml_acervo_geral.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once 'includes/bootstrap.php';
 require_once 'Portabilis/Utils/DeprecatedXmlApi.php';
 require_once 'include/clsBanco.inc.php';
 require_once 'include/pmiacervo/geral.inc.php';

--- a/ieducar/modules/Educacenso/Views/IesAjaxController.php
+++ b/ieducar/modules/Educacenso/Views/IesAjaxController.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once dirname(__FILE__) . '/../../../includes/bootstrap.php';
 require_once 'include/clsBanco.inc.php';
 require_once 'Educacenso/Model/IesDataMapper.php';
 

--- a/ieducar/modules/TabelaArredondamento/Views/TabelaTipoNotaAjax.php
+++ b/ieducar/modules/TabelaArredondamento/Views/TabelaTipoNotaAjax.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once dirname(__FILE__) . '/../../../includes/bootstrap.php';
 require_once 'include/clsBanco.inc.php';
 require_once 'TabelaArredondamento/Model/TabelaDataMapper.php';
 


### PR DESCRIPTION
## Descrição

Remove requires do arquivo `bootstrap.php` para sua futura exclusão.

Modifica o comportamento para quando um ambiente não existir, lança uma exceção `NotFoundHttpException` ao invés de definir a propriedade `ambiente_inexistente`.

Implementação parcial da issue #532.

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**
