### PR TITLE
[2.2] Remove autoload.php fake

### DIFF
--- a/ieducar/intranet/include/clsBase.inc.php
+++ b/ieducar/intranet/include/clsBase.inc.php
@@ -4,7 +4,6 @@ use iEducar\Modules\ErrorTracking\TrackerFactory;
 use iEducar\Support\Navigation\TopMenu;
 use Illuminate\Support\Facades\View;
 
-require_once __DIR__ . '/../../vendor/autoload.php';
 require_once 'clsConfigItajai.inc.php';
 require_once 'include/clsBanco.inc.php';
 require_once 'include/clsControlador.inc.php';

--- a/ieducar/lib/Portabilis/Controller/ReportCoreController.php
+++ b/ieducar/lib/Portabilis/Controller/ReportCoreController.php
@@ -2,7 +2,6 @@
 
 use iEducar\Modules\ErrorTracking\TrackerFactory;
 
-require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once 'Core/Controller/Page/EditController.php';
 require_once 'lib/Portabilis/View/Helper/Inputs.php';
 require_once 'Avaliacao/Model/NotaComponenteDataMapper.php';

--- a/ieducar/lib/Portabilis/Mailer.php
+++ b/ieducar/lib/Portabilis/Mailer.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once 'vendor/autoload.php';
-
 class Portabilis_Mailer
 {
     public $config = [];

--- a/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
@@ -1,7 +1,6 @@
 <?php
 
 require_once 'lib/Portabilis/Report/ReportFactory.php';
-require_once 'vendor/autoload.php';
 
 use JasperPHP\JasperPHP;
 

--- a/ieducar/lib/Portabilis/Utils/ReCaptcha.php
+++ b/ieducar/lib/Portabilis/Utils/ReCaptcha.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once 'vendor/autoload.php';
-
 class Portabilis_Utils_ReCaptcha
 {
     public static function getWidget()

--- a/ieducar/modules/Api/Views/DiarioController.php
+++ b/ieducar/modules/Api/Views/DiarioController.php
@@ -17,9 +17,6 @@ require_once 'include/modules/clsModulesNotaExame.inc.php';
 require_once 'App/Model/MatriculaSituacao.php';
 require_once 'Portabilis/String/Utils.php';
 
-//todo: Mover pra algum outro lugar
-require_once __DIR__ . '/../../../vendor/autoload.php';
-
 class DiarioController extends ApiCoreController
 {
 

--- a/ieducar/modules/Avaliacao/Views/DiarioApiController.php
+++ b/ieducar/modules/Avaliacao/Views/DiarioApiController.php
@@ -21,9 +21,6 @@ require_once 'Portabilis/Array/Utils.php';
 require_once 'Portabilis/String/Utils.php';
 require_once 'Portabilis/Object/Utils.php';
 
-//todo: Mover pra algum outro lugar
-require_once __DIR__ . '/../../../vendor/autoload.php';
-
 class DiarioApiController extends ApiCoreController
 {
     protected $_dataMapper = 'Avaliacao_Model_NotaComponenteDataMapper';

--- a/ieducar/vendor/autoload.php
+++ b/ieducar/vendor/autoload.php
@@ -1,6 +1,0 @@
-<?php
-
-// Este arquivo serve apenas como forma de retrocompatibilidade com a antiga
-// estrutura do i-Educar e será removido no futuro.
-
-require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
## Descrição

Remove autoload.php fake que foi depreciado na versão 2.1.

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**