### PR TITLE
[2.2] Tabela para armazenar as configurações

### DIFF
--- a/app/Setting.php
+++ b/app/Setting.php
@@ -36,6 +36,10 @@ class Setting extends Model
                 return (float) $value;
 
             case self::TYPE_BOOLEAN:
+                if (in_array($value, ['false', 'null'], true)) {
+                    return false;
+                }
+
                 return (boolean) $value;
         }
 

--- a/app/Setting.php
+++ b/app/Setting.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    const TYPE_STRING = 'string';
+    const TYPE_FLOAT = 'float';
+    const TYPE_INTEGER = 'integer';
+    const TYPE_BOOLEAN = 'boolean';
+
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'key', 'value', 'type', 'description',
+    ];
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public function getValueAttribute($value)
+    {
+        switch ($this->type) {
+            case self::TYPE_STRING:
+                return (string) $value;
+
+            case self::TYPE_INTEGER:
+                return (int) $value;
+
+            case self::TYPE_FLOAT:
+                return (float) $value;
+
+            case self::TYPE_BOOLEAN:
+                return (boolean) $value;
+        }
+
+        return $value;
+    }
+}

--- a/database/factories/SettingFactory.php
+++ b/database/factories/SettingFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Setting;
+use Faker\Generator as Faker;
+
+$factory->define(Setting::class, function (Faker $faker) {
+
+    $type = $faker->randomElement([
+        Setting::TYPE_STRING,
+        Setting::TYPE_INTEGER,
+        Setting::TYPE_FLOAT,
+        Setting::TYPE_BOOLEAN,
+    ]);
+
+    if ($type === Setting::TYPE_STRING) {
+        $value = $faker->words(3, true);
+    } elseif ($type === Setting::TYPE_INTEGER) {
+        $value = $faker->numberBetween(0, 1000000);
+    } elseif ($type === Setting::TYPE_FLOAT) {
+        $value = $faker->randomFloat(2, 10, 100);
+    } elseif ($type === Setting::TYPE_BOOLEAN) {
+        $value = $faker->boolean;
+    }
+
+    return [
+        'key' => $faker->toLower(),
+        'value' => $value,
+        'type' => $faker->randomElement(['string', 'integer', 'float', 'boolean']),
+        'description' => $faker->words(3, true),
+    ];
+});

--- a/database/factories/SettingFactory.php
+++ b/database/factories/SettingFactory.php
@@ -23,7 +23,7 @@ $factory->define(Setting::class, function (Faker $faker) {
     }
 
     return [
-        'key' => $faker->toLower(),
+        'key' => $faker->unique()->word,
         'value' => $value,
         'type' => $faker->randomElement(['string', 'integer', 'float', 'boolean']),
         'description' => $faker->words(3, true),

--- a/database/migrations/2019_01_01_100000_create_settings_table.php
+++ b/database/migrations/2019_01_01_100000_create_settings_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateSettingsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->string('type')->default('string');
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('settings');
+    }
+}

--- a/tests/Unit/Eloquent/SettingTest.php
+++ b/tests/Unit/Eloquent/SettingTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\Eloquent;
+
+use App\Setting;
+use Tests\EloquentTestCase;
+
+class SettingTest extends EloquentTestCase
+{
+    /**
+     * @return string
+     */
+    protected function getEloquentModelName()
+    {
+        return Setting::class;
+    }
+}

--- a/tests/Unit/Eloquent/SettingTest.php
+++ b/tests/Unit/Eloquent/SettingTest.php
@@ -14,4 +14,78 @@ class SettingTest extends EloquentTestCase
     {
         return Setting::class;
     }
+
+    /**
+     * @return void
+     */
+    public function testBoolean()
+    {
+        $settingTrueString = factory(Setting::class)->create([
+            'type' => 'boolean',
+            'value' => 'true',
+        ]);
+
+        $settingOneString = factory(Setting::class)->create([
+            'type' => 'boolean',
+            'value' => '1',
+        ]);
+
+        $settingOne = factory(Setting::class)->create([
+            'type' => 'boolean',
+            'value' => 1,
+        ]);
+
+        $settingTrue = factory(Setting::class)->create([
+            'type' => 'boolean',
+            'value' => true,
+        ]);
+
+        $this->assertTrue($settingTrueString->value);
+        $this->assertTrue($settingOneString->value);
+        $this->assertTrue($settingOne->value);
+        $this->assertTrue($settingTrue->value);
+
+        $settingFalseString = factory(Setting::class)->create([
+            'type' => 'boolean',
+            'value' => 'false',
+        ]);
+
+        $settingFalseZeroString = factory(Setting::class)->create([
+            'type' => 'boolean',
+            'value' => '0',
+        ]);
+
+        $settingFalseZero = factory(Setting::class)->create([
+            'type' => 'boolean',
+            'value' => 0,
+        ]);
+
+        $settingFalse = factory(Setting::class)->create([
+            'type' => 'boolean',
+            'value' => false,
+        ]);
+
+        $settingFalseEmptyString = factory(Setting::class)->create([
+            'type' => 'boolean',
+            'value' => '',
+        ]);
+
+        $settingFalseNull = factory(Setting::class)->create([
+            'type' => 'boolean',
+            'value' => null,
+        ]);
+
+        $settingFalseNullString = factory(Setting::class)->create([
+            'type' => 'boolean',
+            'value' => 'null',
+        ]);
+
+        $this->assertFalse($settingFalseString->value);
+        $this->assertFalse($settingFalseZeroString->value);
+        $this->assertFalse($settingFalseZero->value);
+        $this->assertFalse($settingFalse->value);
+        $this->assertFalse($settingFalseEmptyString->value);
+        $this->assertFalse($settingFalseNull->value);
+        $this->assertFalse($settingFalseNullString->value);
+    }
 }


### PR DESCRIPTION
## Descrição

Cria tabela que armazenará as configurações que anteriormente estavam no arquivo `.ini`.

- A chave (_key_) deve ser alfanumérica minúscula separados os níveis por ponto final `app.entity.name`.
- O campo valor (_value_) será sempre um string, mas será convertido para seu determinado tipo no código PHP.
- Tipo (_type_) determina o tipo de campo e o cast que será feito no valor quando utilizado no código PHP. Pode ser `string`, `integer`, `float` ou `boolean`.

<img width="236" alt="Screen Shot 2019-03-18 at 15 43 34" src="https://user-images.githubusercontent.com/957395/54555110-ce801a00-4994-11e9-9844-fbb139c83e94.png">

Implementação #527.

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**