### PR TITLE
[2.2] Adiciona ambiente com PHP 7.3 ao Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,40 @@
-matrix:
+language: php
 
-  include:
+sudo: required
 
-    - language: php
+dist: xenial
 
-      sudo: required
+php:
+  - 7.1
+  - 7.2
+  - 7.3
 
-      dist: xenial
+addons:
+  postgresql: 9.5
+  chrome: stable
 
-      php:
-        - 7.1
-        - 7.2
-        - 7.3
+cache:
+  directories:
+    - $HOME/.composer/cache
 
-      addons:
-        postgresql: 9.5
-        chrome: stable
+before_script:
+  - composer new-install
+  - vendor/laravel/dusk/bin/chromedriver-linux > /dev/null 2>&1 &
+  - php artisan serve > /dev/null 2>&1 &
 
-      env:
-        - APP_URL=http://localhost:8000
-        - APP_ENV=testing
-        - DB_CONNECTION=pgsql
-        - DB_HOST=localhost
-        - DB_PORT=5432
-        - DB_DATABASE=travis
-        - DB_USERNAME=postgres
-        - DB_PASSWORD=
-        - API_ACCESS_KEY=ieducar-access-key
-        - API_SECRET_KEY=ieducar-secret-key
+script:
+  - vendor/bin/phpunit
+  - php artisan dusk
 
-      cache:
-        directories:
-          - $HOME/.composer/cache
-
-      before_script:
-        - composer new-install
-        - vendor/laravel/dusk/bin/chromedriver-linux > /dev/null 2>&1 &
-        - php artisan serve > /dev/null 2>&1 &
-
-      script:
-        - vendor/bin/phpunit
-        - php artisan dusk
+env:
+  global:
+    - APP_URL=http://localhost:8000
+    - APP_ENV=testing
+    - DB_CONNECTION=pgsql
+    - DB_HOST=localhost
+    - DB_PORT=5432
+    - DB_DATABASE=travis
+    - DB_USERNAME=postgres
+    - DB_PASSWORD=
+    - API_ACCESS_KEY=ieducar-access-key
+    - API_SECRET_KEY=ieducar-secret-key

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
       php:
         - 7.1
         - 7.2
+        - 7.3
 
       addons:
         postgresql: 9.5


### PR DESCRIPTION
## Descrição

Adiciona ambiente com PHP 7.3 ao Travis e corrige a matriz de ambientes.

Antes os testes eram executados apenas na versão 7.1 do PHP, agora são executados na versão 7.1, 7.2 e 7.3.

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**