### PR TITLE
Correção do erro na exclusão de um compromisso

### DIFF
--- a/ieducar/intranet/agenda.php
+++ b/ieducar/intranet/agenda.php
@@ -399,7 +399,7 @@ class indice extends clsCadastro
                                     <div>
                                         <i class=\"fa fa-pencil\" aria-hidden=\"true\"></i> Editar
                                     </div></a>
-                                <a class=\"small\" href=\"javascript: excluir( {$cod_agenda_compromisso} );\">
+                                <a class=\"small\" href=\"javascript: excluir_compromisso( {$cod_agenda_compromisso} );\">
                                 <div>
                                         <i class=\"fa fa-close\" aria-hidden=\"true\"></i> Excluir
                                 </div></a>";

--- a/ieducar/intranet/scripts/agenda.js
+++ b/ieducar/intranet/scripts/agenda.js
@@ -186,7 +186,7 @@ function agenda_retrair( compId )
 	document.getElementById( "aberto_" + compId ).value = 0;
 }
 
-function excluir( compId )
+function excluir_compromisso( compId )
 {
 	if( confirm( 'Deseja realmente excluir este compromisso?\nEsta e uma operacao irreversivel!' ) )
 	{


### PR DESCRIPTION
## Descrição
Correção na exclusão de um compromisso

## Contexto e motivação
Correção do erro constatado pelo @edersoares na pull [550](https://github.com/portabilis/i-educar/pull/550), ao tentar excluir um compromisso dava erro:

`Uncaught TypeError: Cannot read property 'reset' of undefined
    at excluir (agenda.php?cod_agenda=1&time=1553711156:680)
    at <anonymous>:1:2`

## Tipos de alterações
- ✅ Bug fix (Não quebra outras funcionalidades)

## Checklist:
<!--- Verifique todos os pontos. -->
<!--- Novamente, remova todas as linhas que não foram aplicadas. -->
<!--- Pull Requests que não atenderem todos os [REQUIRED] provavelmente não serão aceitos -->

- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**
- x Minhas alterações necessitam de alteração na documentação e já foram feitas.
- x Criei testes automatizados que cobrem minhas alterações.
