### PR TITLE
Desabilita Dusk temporariamente

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,3 @@ matrix:
 
       script:
         - vendor/bin/phpunit
-        - php artisan dusk


### PR DESCRIPTION
Após a atualização do ChromeDriver, existe problemas com os binários do Laravel Dusk que não estão conseguindo utilizar sessão ao executar os testes de browser. A intenção é habilitar novamente os testes de browser assim que o problema for corrigido.

Mais informações na issue https://github.com/laravel/dusk/issues/641.