### PR TITLE
[2.2] Substitui o uso de $coreExt

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -59,13 +59,8 @@ class AppServiceProvider extends ServiceProvider
      */
     private function loadLegacyBootstrap()
     {
-        global $coreExt;
-
-        $coreExt = [];
-        $coreExt['Config'] = json_decode(json_encode(config('legacy')));
-
         setlocale(LC_ALL, 'en_US.UTF-8');
-        date_default_timezone_set($coreExt['Config']->app->locale->timezone);
+        date_default_timezone_set(config('legacy.app.locale.timezone'));
     }
 
     /**

--- a/ieducar/intranet/atendidos_cad.php
+++ b/ieducar/intranet/atendidos_cad.php
@@ -191,7 +191,7 @@ class indice extends clsCadastro
 
     public function Gerar()
     {
-        $camposObrigatorios = !$GLOBALS['coreExt']['Config']->app->remove_obrigatorios_cadastro_pessoa == 1;
+        $camposObrigatorios = !config('legacy.app.remove_obrigatorios_cadastro_pessoa') == 1;
         $obrigarCamposCenso = $this->validarCamposObrigatoriosCenso();
         $this->campoOculto('obrigar_campos_censo', (int) $obrigarCamposCenso);
         $this->url_cancelar = $this->retorno == 'Editar' ?
@@ -327,7 +327,7 @@ class indice extends clsCadastro
 
         $required = (! empty($parentType));
 
-        if ($required && $GLOBALS['coreExt']['Config']->app->rg_pessoa_fisica_pais_opcional) {
+        if ($required && config('legacy.app.rg_pessoa_fisica_pais_opcional')) {
             $required = false;
         }
 

--- a/ieducar/intranet/educar_aluno_det.php
+++ b/ieducar/intranet/educar_aluno_det.php
@@ -1024,7 +1024,7 @@ class indice extends clsDetalhe
         $this->largura = '100%';
         $this->addDetalhe("<input type='hidden' id='escola_id' name='aluno_id' value='{$registro['ref_cod_escola']}' />");
         $this->addDetalhe("<input type='hidden' id='aluno_id' name='aluno_id' value='{$registro['cod_aluno']}' />");
-        $mostraDependencia = $GLOBALS['coreExt']['Config']->app->matricula->dependencia;
+        $mostraDependencia = config('legacy.app.matricula.dependencia');
         $this->addDetalhe("<input type='hidden' id='can_show_dependencia' name='can_show_dependencia' value='{$mostraDependencia}' />");
         
         $this->breadcrumb('Aluno', ['/intranet/educar_index.php' => 'Escola']);

--- a/ieducar/intranet/educar_exportacao_educacenso.php
+++ b/ieducar/intranet/educar_exportacao_educacenso.php
@@ -110,7 +110,7 @@ class indice extends clsCadastro
       $this->campoOculto("fase2", "true");
     }
 
-    $this->campoOculto("enable_export", (int)$GLOBALS['coreExt']['Config']->educacenso->enable_export);
+    $this->campoOculto("enable_export", (int) config('legacy.educacenso.enable_export'));
     $this->inputsHelper()->dynamic(array('ano', 'instituicao', 'escola'));
     $this->inputsHelper()->hidden('escola_em_andamento', [ 'value' => $this->escola_em_andamento ]);
 

--- a/ieducar/intranet/educar_matricula_cad.php
+++ b/ieducar/intranet/educar_matricula_cad.php
@@ -179,7 +179,7 @@ class indice extends clsCadastro
         $this->inputsHelper()->date('data_matricula', ['label' => Portabilis_String_Utils::toLatin1('Data da matrícula'), 'placeholder' => 'dd/mm/yyyy', 'value' => date('d/m/Y')]);
         $this->inputsHelper()->hidden('ano_em_andamento', ['value' => '1']);
 
-        if ($GLOBALS['coreExt']['Config']->app->matricula->dependencia == 1) {
+        if (config('legacy.app.matricula.dependencia') == 1) {
             $this->inputsHelper()->checkbox(
                 'dependencia',
                 [
@@ -458,7 +458,7 @@ class indice extends clsCadastro
                     $cursoADeferir = new clsPmieducarCurso($this->ref_cod_curso);
                     $cursoDeAtividadeComplementar = $cursoADeferir->cursoDeAtividadeComplementar();
 
-                    if (($mesmoCursoAno || $GLOBALS['coreExt']['Config']->app->matricula->multiplas_matriculas === 0) && !$cursoDeAtividadeComplementar) {
+                    if (($mesmoCursoAno || config('legacy.app.matricula.multiplas_matriculas') === 0) && !$cursoDeAtividadeComplementar) {
                         require_once 'include/pmieducar/clsPmieducarEscola.inc.php';
                         require_once 'include/pessoa/clsJuridica.inc.php';
 

--- a/ieducar/intranet/educar_matricula_ocorrencia_disciplinar_cad.php
+++ b/ieducar/intranet/educar_matricula_ocorrencia_disciplinar_cad.php
@@ -375,7 +375,7 @@ class indice extends clsCadastro
     $tipo_ocorrencia = $det_tmp["nm_tipo"];
 
     $params   = [
-      'token'        => $GLOBALS['coreExt']['Config']->apis->access_key,
+      'token'        => config('legacy.apis.access_key'),
       'api_code'     => $cod_ocorrencia_disciplinar,
       'student_code' => $cod_aluno,
       'description'  => $this->observacao,
@@ -389,8 +389,8 @@ class indice extends clsCadastro
       'recurso'        => 'ocorrencias-disciplinares',
       'tipoRequisicao' => ApiExternaController::REQUISICAO_POST,
       'params'         => $params,
-      'token_header' => $GLOBALS['coreExt']['Config']->apis->educacao_token_header,
-      'token_key'    => $GLOBALS['coreExt']['Config']->apis->educacao_token_key,
+      'token_header' => config('legacy.apis.educacao_token_header'),
+      'token_key'    => config('legacy.apis.educacao_token_key'),
     ]
     );
 

--- a/ieducar/intranet/educar_pesquisa_cep_log_bairro.php
+++ b/ieducar/intranet/educar_pesquisa_cep_log_bairro.php
@@ -70,8 +70,6 @@ class miolo1 extends clsListagem
 
   function Gerar()
   {
-    global $coreExt;
-
     Session::put([
         'campo1' => $_GET['campo1'] ?? Session::get('campo1'),
         'campo2' => $_GET['campo2'] ?? Session::get('campo2'),
@@ -115,7 +113,7 @@ class miolo1 extends clsListagem
 
     // uf
 
-    $defaultProvince = isset($_GET['ref_sigla_uf']) ? $_GET['ref_sigla_uf'] : $coreExt['Config']->app->locale->province;
+    $defaultProvince = isset($_GET['ref_sigla_uf']) ? $_GET['ref_sigla_uf'] : config('legacy.app.locale.province');
 
     $options = array(
       'required' => false,

--- a/ieducar/intranet/educar_pesquisa_cep_log_bairro2.php
+++ b/ieducar/intranet/educar_pesquisa_cep_log_bairro2.php
@@ -70,8 +70,6 @@ class miolo1 extends clsListagem
 
   function Gerar()
   {
-    global $coreExt;
-
     Session::put([
       'campo1' => $_GET['campo1'] ?? Session::get('campo1'),
       'campo2' => $_GET['campo2'] ?? Session::get('campo2'),
@@ -115,7 +113,7 @@ class miolo1 extends clsListagem
 
     // uf
 
-    $defaultProvince = isset($_GET['ref_sigla_uf']) ? $_GET['ref_sigla_uf'] : $coreExt['Config']->app->locale->province;
+    $defaultProvince = isset($_GET['ref_sigla_uf']) ? $_GET['ref_sigla_uf'] : config('legacy.app.locale.province');
 
     $options = array(
       'required' => false,

--- a/ieducar/intranet/educar_pesquisa_municipio_lst.php
+++ b/ieducar/intranet/educar_pesquisa_municipio_lst.php
@@ -80,9 +80,6 @@ class indice extends clsListagem
 
     function Gerar()
     {
-        global $coreExt;
-        $config = $coreExt['Config']->app->locale;
-
         Session::put([
             'campo1' => $_GET["campo1"] ? $_GET["campo1"] : Session::get('campo1')
         ]);
@@ -111,7 +108,7 @@ class indice extends clsListagem
         }
         if(!isset($this->sigla_uf))
         {
-            $this->sigla_uf = $config->province ? $config->province : '';
+            $this->sigla_uf = config('legacy.app.locale.province', '');
         }
 
 

--- a/ieducar/intranet/educar_usuario_cad.php
+++ b/ieducar/intranet/educar_usuario_cad.php
@@ -235,7 +235,7 @@ class indice extends clsCadastro
 
         $this->campoLista("tempo_expira_conta", "Dias p/ expirar a conta", $opcoes, $this->tempo_expira_conta);
 
-        $tempoExpiraSenha = $GLOBALS['coreExt']['Config']->app->user_accounts->default_password_expiration_period;
+        $tempoExpiraSenha = config('legacy.app.user_accounts.default_password_expiration_period');
 
         if (is_numeric($tempoExpiraSenha))
             $this->campoOculto("tempo_expira_senha", $tempoExpiraSenha);

--- a/ieducar/intranet/funcionario_cad.php
+++ b/ieducar/intranet/funcionario_cad.php
@@ -212,7 +212,7 @@ class indice extends clsCadastro
 
         $this->campoLista("tempo_expira_conta", "Dias p/ expirar a conta", $opcoes, $this->tempo_expira_conta);
 
-        $tempoExpiraSenha = $GLOBALS['coreExt']['Config']->app->user_accounts->default_password_expiration_period;
+        $tempoExpiraSenha = config('legacy.app.user_accounts.default_password_expiration_period');
 
         if (is_numeric($tempoExpiraSenha))
             $this->campoOculto("tempo_expira_senha", $tempoExpiraSenha);

--- a/ieducar/intranet/include/clsBase.inc.php
+++ b/ieducar/intranet/include/clsBase.inc.php
@@ -101,7 +101,7 @@ class clsBase
             $saida = str_replace('<!-- #&SCRIPT_HEADER&# -->', '', $saida);
         }
 
-        $saida = str_replace('<!-- #&GOOGLE_TAG_MANAGER_ID&# -->', $GLOBALS['coreExt']['Config']->app->gtm->id, $saida);
+        $saida = str_replace('<!-- #&GOOGLE_TAG_MANAGER_ID&# -->', config('legacy.app.gtm.id'), $saida);
 
         // nome completo usuario
         // @TODO: jeito mais eficiente de usar estes dados, já que eles são
@@ -110,7 +110,7 @@ class clsBase
         list($nomePessoa, $email) = $nomePessoa->queryRapida($this->currentUserId(), 'nome', 'email');
         $nomePessoa = ($nomePessoa) ? $nomePessoa : 'Visitante';
 
-        $saida = str_replace('<!-- #&SLUG&# -->', $GLOBALS['coreExt']['Config']->app->database->dbname, $saida);
+        $saida = str_replace('<!-- #&SLUG&# -->', config('legacy.app.database.dbname'), $saida);
         $saida = str_replace('<!-- #&USERLOGADO&# -->', trim($nomePessoa), $saida);
         $saida = str_replace('<!-- #&USEREMAIL&# -->', trim($email), $saida);
 

--- a/ieducar/intranet/include/pessoa/clsUf.inc.php
+++ b/ieducar/intranet/include/pessoa/clsUf.inc.php
@@ -46,9 +46,6 @@ class clsUf
      */
     function __construct( $str_sigla_uf=false, $str_nome=false, $str_geom=false, $int_idpais=false )
     {
-        global $coreExt;
-        $this->config = $coreExt['Config'];
-
         $this->sigla_uf = $str_sigla_uf;
         $this->nome = $str_nome;
         $this->geom = $str_geom;
@@ -178,7 +175,7 @@ class clsUf
       $whereAnd = ' AND ';
     }
     else {
-      $idpais = $this->config->app->locale->country;
+      $idpais = config('legacy.app.locale.country');
       $where .= "{$whereAnd}idpais = '$idpais'";
       $whereAnd = ' AND ';
     }

--- a/ieducar/intranet/include/relatorio.inc.php
+++ b/ieducar/intranet/include/relatorio.inc.php
@@ -88,10 +88,6 @@ class relatorios
 
   public function novaPagina($altura_titulo = 12, $tamanho_titulo = 14)
   {
-    // Recupera objeto no escopo global
-    global $coreExt;
-    $config = $coreExt['Config']->app->template;
-
     $this->altura_titulo = $altura_titulo;
     $this->tamanho_titulo = $tamanho_titulo;
     $this->numeroPagina++;
@@ -121,7 +117,7 @@ class relatorios
     $this->pdf->Write( $this->numeroPagina, $this->pdf->largura - $this->margem_direita - 25, 125, 15, 80, $this->fonte_titulo, 10, "#000000", "center" );
 
     // Insere o brasao da prefeitura
-    $image = $config->get($config->pdf->logo, 'imagens/brasao.gif');
+    $image = config('legacy.app.template.pdf.logo', 'imagens/brasao.gif');
     $this->pdf->insertImageScaled("gif", $image, $this->margem_esquerda + 4,
       74, 45);
 

--- a/ieducar/intranet/index.php
+++ b/ieducar/intranet/index.php
@@ -89,8 +89,8 @@ class indice
         $temp .= "<center><h3>Acesso negado para este usu&aacute;rio.</h3><br>Caso persista nas tentativas sua conta na intranet poder&aacute; ser bloqueada por tempo indeterminado.</center>";
       }
 
-      $pendencia_administrativa = dbBool($GLOBALS['coreExt']['Config']->app->administrative_pending->exist);
-      $texto_pendencia = $GLOBALS['coreExt']['Config']->app->administrative_pending->msg;
+      $pendencia_administrativa = dbBool(config('legacy.app.administrative_pending.exist'));
+      $texto_pendencia = config('legacy.app.administrative_pending.msg');
 
       if ($pendencia_administrativa)
         echo '

--- a/ieducar/intranet/meusdados.php
+++ b/ieducar/intranet/meusdados.php
@@ -294,8 +294,8 @@ class indice extends clsCadastro
         ];
 
         $rdStationParams = [
-            'token' => $GLOBALS['coreExt']['Config']->app->rdstation->token,
-            'private_token' => $GLOBALS['coreExt']['Config']->app->rdstation->private_token
+            'token' => config('legacy.app.rdstation.token'),
+            'private_token' => config('legacy.app.rdstation.private_token')
         ];
 
         if (!empty($rdStationParams['token']) && !empty($rdStationParams['private_token'])) {

--- a/ieducar/intranet/s3_config.php
+++ b/ieducar/intranet/s3_config.php
@@ -1,9 +1,9 @@
 <?php
 
-$bucket = $GLOBALS['coreExt']['Config']->app->aws->bucketname;
-$directory = $GLOBALS['coreExt']['Config']->app->database->dbname . '/';
-$key = $GLOBALS['coreExt']['Config']->app->aws->awsacesskey;
-$secretKey = $GLOBALS['coreExt']['Config']->app->aws->awssecretkey;
+$bucket = config('legacy.app.aws.bucketname');
+$directory = config('legacy.app.database.dbname') . '/';
+$key = config('legacy.app.aws.awsacesskey');
+$secretKey = config('legacy.app.aws.awssecretkey');
 
 if (!class_exists('S3')) {
     require_once 'S3.php';

--- a/ieducar/lib/Core/View.php
+++ b/ieducar/lib/Core/View.php
@@ -96,17 +96,13 @@ class Core_View extends clsBase
     }
 
     /**
-     * Configura algumas variáveis de instância usando o container global
-     * $coreExt.
-     *
-     * @global $coreExt
+     * Configura algumas variáveis de instância.
      *
      * @see clsBase#Formular()
      */
     public function Formular()
     {
-        global $coreExt;
-        $instituicao = $coreExt['Config']->app->template->vars->instituicao;
+        $instituicao = config('legacy.app.template.vars.instituicao');
 
         $this->setTitulo($instituicao . ' | ' . $this->_getPageController()->getBaseTitulo())
             ->setProcessoAp($this->_getPageController()->getBaseProcessoAp());

--- a/ieducar/lib/Portabilis/Controller/ApiCoreController.php
+++ b/ieducar/lib/Portabilis/Controller/ApiCoreController.php
@@ -60,7 +60,7 @@ class ApiCoreController extends Core_Controller_Page_EditController
         $valid = false;
 
         if (!is_null($this->getRequest()->access_key)) {
-            $accessKey = $GLOBALS['coreExt']['Config']->apis->access_key;
+            $accessKey = config('legacy.apis.access_key');
             $valid = $accessKey == $this->getRequest()->access_key;
 
             if (!$valid) {

--- a/ieducar/lib/Portabilis/Controller/ReportCoreController.php
+++ b/ieducar/lib/Portabilis/Controller/ReportCoreController.php
@@ -71,9 +71,9 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
 
             $this->beforeValidation();
 
-            $this->report->addArg('database', ($GLOBALS['coreExt']['Config']->app->database->dbname == 'test' ? (is_null($GLOBALS['coreExt']['Config']->report->database_teste) ? '' : $GLOBALS['coreExt']['Config']->report->database_teste) : $GLOBALS['coreExt']['Config']->app->database->dbname));
-            $this->report->addArg('SUBREPORT_DIR', $GLOBALS['coreExt']['Config']->report->source_path);
-            $this->report->addArg('data_emissao', (int) $GLOBALS['coreExt']['Config']->report->header->show_data_emissao);
+            $this->report->addArg('database', (config('legacy.app.database.dbname') == 'test' ? (is_null(config('legacy.report.database_teste')) ? '' : config('legacy.report.database_teste')) : config('legacy.app.database.dbname')));
+            $this->report->addArg('SUBREPORT_DIR', config('legacy.report.source_path'));
+            $this->report->addArg('data_emissao', (int) config('legacy.report.header.show_data_emissao'));
 
             $this->validatesPresenseOfRequiredArgsInReport();
             $this->aftervalidation();
@@ -142,14 +142,14 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
             echo $result;
             die();
         } catch (Exception $e) {
-            if ($GLOBALS['coreExt']['Config']->modules->error->track) {
-                $tracker = TrackerFactory::getTracker($GLOBALS['coreExt']['Config']->modules->error->tracker_name);
+            if (config('legacy.modules.error.track')) {
+                $tracker = TrackerFactory::getTracker(config('legacy.modules.error.tracker_name'));
                 $tracker->notify($e);
             }
 
             $nivelUsuario = (new clsPermissoes)->nivel_acesso($this->getSession()->id_pessoa);
 
-            if ((bool) $GLOBALS['coreExt']['Config']->report->show_error_details === true || (int) $nivelUsuario === 1) {
+            if ((bool) config('legacy.report.show_error_details') === true || (int) $nivelUsuario === 1) {
                 $details = 'Detalhes: ' . $e->getMessage();
             } else {
                 $details = 'Visualização dos detalhes sobre o erro desativada.';

--- a/ieducar/lib/Portabilis/Report/ReportCore.php
+++ b/ieducar/lib/Portabilis/Report/ReportCore.php
@@ -127,7 +127,7 @@ abstract class Portabilis_Report_ReportCore
      */
     public function reportFactory()
     {
-        $factoryClassName = $GLOBALS['coreExt']['Config']->report->default_factory;
+        $factoryClassName = config('legacy.report.default_factory');
         $factoryClassPath = str_replace('_', '/', $factoryClassName) . '.php';
 
         if (!$factoryClassName) {

--- a/ieducar/lib/Portabilis/Report/ReportFactory.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactory.php
@@ -21,7 +21,7 @@ abstract class Portabilis_Report_ReportFactory
      */
     public function __construct()
     {
-        $this->config = $GLOBALS['coreExt']['Config'];
+        $this->config = json_decode(json_encode(config('legacy')));
         $this->settings = [];
 
         $this->setSettings($this->config);

--- a/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
@@ -26,7 +26,7 @@ class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportF
      */
     public function getReportsPath()
     {
-        return $GLOBALS['coreExt']['Config']->report->source_path;
+        return config('legacy.report.source_path');
     }
 
     /**

--- a/ieducar/lib/Portabilis/Utils/ReCaptcha.php
+++ b/ieducar/lib/Portabilis/Utils/ReCaptcha.php
@@ -4,15 +4,14 @@ class Portabilis_Utils_ReCaptcha
 {
     public static function getWidget()
     {
-        $config = $GLOBALS['coreExt']['Config']->app->recaptcha;
         $template = '<div class="g-recaptcha" data-sitekey="%s"></div><script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl=%s"></script>';
 
-        return sprintf($template, $config->public_key, $config->options->lang);
+        return sprintf($template, config('legacy.app.recaptcha.public_key'), config('legacy.app.recaptcha.options.lang'));
     }
 
     public static function check($response)
     {
-        $recaptcha = new \ReCaptcha\ReCaptcha($GLOBALS['coreExt']['Config']->app->recaptcha->private_key);
+        $recaptcha = new \ReCaptcha\ReCaptcha(config('legacy.app.recaptcha.private_key'));
         $resp = $recaptcha->verify($response, $_SERVER['REMOTE_ADDR']);
 
         return $resp->isSuccess();

--- a/ieducar/lib/Portabilis/Utils/User.php
+++ b/ieducar/lib/Portabilis/Utils/User.php
@@ -68,7 +68,7 @@ class Portabilis_Utils_User
 
         $options = ['params' => [$id], 'show_errors' => false, 'return_only' => 'first-line'];
         $user = self::fetchPreparedQuery($sql, $options);
-        $user['super'] = $GLOBALS['coreExt']['Config']->app->superuser == $user['matricula'];
+        $user['super'] = config('legacy.app.superuser') == $user['matricula'];
 
         // considera como expirado caso usuario não admin e data_reativa_conta + tempo_expira_conta <= now
         // obs: ao salvar drh > cadastro funcionario, seta data_reativa_conta = now
@@ -80,7 +80,7 @@ class Portabilis_Utils_User
 
         // considera o periodo para expiração de senha definido nas configs, caso o tenha sido feito.
 
-        $tempoExpiraSenha = $GLOBALS['coreExt']['Config']->app->user_accounts->default_password_expiration_period;
+        $tempoExpiraSenha = config('legacy.app.user_accounts.default_password_expiration_period');
 
         if (!is_numeric($tempoExpiraSenha)) {
             $tempoExpiraSenha = $user['tempo_expira_senha'];

--- a/ieducar/modules/Api/Views/AlunoController.php
+++ b/ieducar/modules/Api/Views/AlunoController.php
@@ -243,7 +243,7 @@ class AlunoController extends ApiCoreController
 
     protected function validaTurnoProjeto($alunoId, $turnoId)
     {
-        if ($GLOBALS['coreExt']['Config']->app->projetos->ignorar_turno_igual_matricula == 1) {
+        if (config('legacy.app.projetos.ignorar_turno_igual_matricula') == 1) {
             return true;
         }
 
@@ -504,7 +504,7 @@ class AlunoController extends ApiCoreController
             $aluno->ref_idpes = $this->getRequest()->pessoa_id;
         }
 
-        if (!$GLOBALS['coreExt']['Config']->app->alunos->nao_apresentar_campo_alfabetizado) {
+        if (!config('legacy.app.alunos.nao_apresentar_campo_alfabetizado')) {
             $aluno->analfabeto = $this->getRequest()->alfabetizado ? 0 : 1;
         }
 

--- a/ieducar/modules/Api/Views/ReportController.php
+++ b/ieducar/modules/Api/Views/ReportController.php
@@ -84,7 +84,7 @@ class ReportController extends ApiCoreController
             $boletimReport->addArg('serie', (int)$dadosMatricula['serie_id']);
             $boletimReport->addArg('turma', (int)$dadosMatricula['turma_id']);
             $boletimReport->addArg('situacao_matricula', 10);
-            $boletimReport->addArg('SUBREPORT_DIR', $GLOBALS['coreExt']['Config']->report->source_path);
+            $boletimReport->addArg('SUBREPORT_DIR', config('legacy.report.source_path'));
 
             $encoding = 'base64';
             $dumpsOptions = ['options' => ['encoding' => $encoding]];
@@ -121,7 +121,7 @@ class ReportController extends ApiCoreController
 
             $boletimProfessorReport->addArg('modelo', $modelo);
             $boletimProfessorReport->addArg('linha', 0);
-            $boletimProfessorReport->addArg('SUBREPORT_DIR', $GLOBALS['coreExt']['Config']->report->source_path);
+            $boletimProfessorReport->addArg('SUBREPORT_DIR', config('legacy.report.source_path'));
 
             $encoding = 'base64';
 

--- a/ieducar/modules/Avaliacao/Views/DiarioApiController.php
+++ b/ieducar/modules/Avaliacao/Views/DiarioApiController.php
@@ -1647,7 +1647,7 @@ class DiarioApiController extends ApiCoreController
             $itensRegra['quantidade_etapas'] = $this->serviceBoletim()->getOption('etapas');
         }
 
-        $itensRegra['nomenclatura_exame'] = ($GLOBALS['coreExt']['Config']->app->diario->nomenclatura_exame == 0 ? 'exame' : 'conselho');
+        $itensRegra['nomenclatura_exame'] = (config('legacy.app.diario.nomenclatura_exame') == 0 ? 'exame' : 'conselho');
 
         //tipo de recuperação paralela
         $tipoRecuperacaoParalela = $regra->get('tipoRecuperacaoParalela');
@@ -1693,7 +1693,7 @@ class DiarioApiController extends ApiCoreController
 
     protected function usaAuditoriaNotas()
     {
-        return ($GLOBALS['coreExt']['Config']->app->auditoria->notas == "1");
+        return (config('legacy.app.auditoria.notas') == "1");
     }
 
     public function canChange()

--- a/ieducar/modules/Avaliacao/Views/DiarioController.php
+++ b/ieducar/modules/Avaliacao/Views/DiarioController.php
@@ -74,7 +74,7 @@ class DiarioController extends Portabilis_Controller_Page_ListController
 
     $this->inputsHelper()->select('navegacao_tab', $options);
 
-    $this->inputsHelper()->hidden('mostrar_botao_replicar_todos', array('value' => $teste = $GLOBALS['coreExt']['Config']->app->faltas_notas->mostrar_botao_replicar));
+    $this->inputsHelper()->hidden('mostrar_botao_replicar_todos', array('value' => $teste = config('legacy.app.faltas_notas.mostrar_botao_replicar')));
 
     $this->loadResourceAssets($this->getDispatcher());
   }

--- a/ieducar/modules/Cadastro/Views/AlunoController.php
+++ b/ieducar/modules/Cadastro/Views/AlunoController.php
@@ -337,7 +337,7 @@ class AlunoController extends Portabilis_Controller_Page_EditController
         $configuracoes = new clsPmieducarConfiguracoesGerais();
         $configuracoes = $configuracoes->detalhe();
 
-        $labels_botucatu = $GLOBALS['coreExt']['Config']->app->mostrar_aplicacao == 'botucatu';
+        $labels_botucatu = config('legacy.app.mostrar_aplicacao') == 'botucatu';
 
         if ($configuracoes["justificativa_falta_documentacao_obrigatorio"]) {
             $this->inputsHelper()->hidden('justificativa_falta_documentacao_obrigatorio');
@@ -402,9 +402,9 @@ class AlunoController extends Portabilis_Controller_Page_EditController
         );
 
         // código aluno sistema
-        if ($GLOBALS['coreExt']['Config']->app->alunos->mostrar_codigo_sistema) {
+        if (config('legacy.app.alunos.mostrar_codigo_sistema')) {
             $options = array(
-                'label' => Portabilis_String_Utils::toLatin1($GLOBALS['coreExt']['Config']->app->alunos->codigo_sistema),
+                'label' => Portabilis_String_Utils::toLatin1(config('legacy.app.alunos.codigo_sistema')),
                 'required' => false,
                 'size' => 25,
                 'max_length' => 30
@@ -896,7 +896,7 @@ class AlunoController extends Portabilis_Controller_Page_EditController
         $options = array('label' => $this->_getLabel('alfabetizado'), 'value' => 'checked');
         $this->inputsHelper()->checkbox('alfabetizado', $options);
 
-        if ($GLOBALS['coreExt']['Config']->app->alunos->nao_apresentar_campo_alfabetizado) {
+        if (config('legacy.app.alunos.nao_apresentar_campo_alfabetizado')) {
             $this->inputsHelper()->hidden('alfabetizado');
         }
 
@@ -908,7 +908,7 @@ class AlunoController extends Portabilis_Controller_Page_EditController
 
         $this->inputsHelper()->hidden('url_laudo_medico');
 
-        if ($GLOBALS['coreExt']['Config']->app->alunos->laudo_medico_obrigatorio == 1) {
+        if (config('legacy.app.alunos.laudo_medico_obrigatorio') == 1) {
             $this->inputsHelper()->hidden('url_laudo_medico_obrigatorio');
         }
 

--- a/ieducar/modules/Docente/Views/EditController.php
+++ b/ieducar/modules/Docente/Views/EditController.php
@@ -72,8 +72,6 @@ class EditController extends Core_Controller_Page_EditController
      */
     public function Gerar()
     {
-        global $coreExt;
-
         $this->campoOculto('id', $this->getEntity()->id);
         $this->campoOculto('servidor', $this->getRequest()->servidor);
 
@@ -135,7 +133,7 @@ class EditController extends Core_Controller_Page_EditController
         // Caso não seja uma instância persistida, usa a UF do locale.
         $uf = $this->getEntity()->ies->uf
             ? $this->getEntity()->ies->uf
-            : $coreExt['Config']->app->locale->province;
+            : config('legacy.app.locale.province');
 
         $this->campoLista('uf', 'UF', $opcoes, $uf, 'getIes()');
 

--- a/ieducar/modules/HistoricoEscolar/Views/ProcessamentoApiController.php
+++ b/ieducar/modules/HistoricoEscolar/Views/ProcessamentoApiController.php
@@ -683,7 +683,7 @@ class ProcessamentoApiController extends Core_Controller_Page_EditController
                     $nota = $this->DISCIPLINA_DISPENSADA;
                 } elseif ($this->getRequest()->notas == 'buscar-boletim') {
                     if ($tpNota == $cnsNota::CONCEITUAL) {
-                        if ($GLOBALS['coreExt']['Config']->app->processar_historicos_conceituais == '1') {
+                        if (config('legacy.app.processar_historicos_conceituais') == '1') {
                             $nota = (string)$mediasCc[$ccId][0]->mediaArredondada;
                             $notaConceitualNumerica = (string)$mediasCc[$ccId][0]->media;
                         }

--- a/src/Modules/ErrorTracking/EmailTracker.php
+++ b/src/Modules/ErrorTracking/EmailTracker.php
@@ -33,6 +33,6 @@ class EmailTracker implements Tracker
 
     private function getRecipient()
     {
-        return $GLOBALS['coreExt']['Config']->modules->error->email_recipient;
+        return config('legacy.modules.error.email_recipient');
     }
 }


### PR DESCRIPTION
Após o PR https://github.com/portabilis/i-educar/pull/537 se tornou possível utilizar as configurações que antes eram acessadas via a variável global `$coreExt` através do helper `config()`, para isso, foi necessário fazer a troca de todas as referências a `$coreExt` e `$GLOBALS['coreExt']`.