### PR TITLE
Retorna conteúdo do PDF na factory PHP Jasper

### DIFF
--- a/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
@@ -140,32 +140,13 @@ class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportF
 
         $outputFile .= '.pdf';
 
-        $this->showPDF($outputFile);
+        $result = file_exists($outputFile)
+            ? file_get_contents($outputFile)
+            : null;
+
         $this->destroyPDF($outputFile);
-    }
 
-    /**
-     * Lê o PDF gerado para a saída de conteúdo.
-     *
-     * @param string $file
-     *
-     * @return void
-     */
-    public function showPDF($file)
-    {
-        header('Pragma: public');
-        header('Expires: 0');
-        header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
-        header('Cache-Control: private', false);
-        header('Content-Type: application/pdf;');
-        header('Content-Disposition: inline;');
-        header('Content-Transfer-Encoding: binary');
-        header('Content-Length: ' . filesize($file));
-
-        ob_clean();
-        flush();
-
-        readfile($file);
+        return $result;
     }
 
     /**
@@ -177,6 +158,8 @@ class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportF
      */
     public function destroyPDF($file)
     {
-        unlink($file);
+        if (file_exists($file)) {
+            unlink($file);
+        }
     }
 }


### PR DESCRIPTION
## Descrição

A factory estava tentando mostrar o relatório o que causava conflito com o tratamento de output feito pelo `ReportCoreController`. A factory foi ajustada para apenas retornar o conteúdo do PDF quando este for gerado com sucesso.

## Contexto e motivação

Referente à issue #575 

## Tipos de alterações

- ✅ Bug fix (Não quebra outras funcionalidades)

## Checklist:

- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
