### PR TITLE
[2.2] Remove a chave estrangeira do código lingua indígena

### DIFF
--- a/database/migrations/legacy/2019_01_01_200000_add_foreign_keys_on_pmieducar_escola_table.php
+++ b/database/migrations/legacy/2019_01_01_200000_add_foreign_keys_on_pmieducar_escola_table.php
@@ -52,10 +52,6 @@ class AddForeignKeysOnPmieducarEscolaTable extends Migration
                ->onUpdate('restrict')
                ->onDelete('restrict');
 
-            $table->foreign('codigo_lingua_indigena')
-               ->references('id')
-               ->on('modules.lingua_indigena_educacenso');
-
             $table->foreign('codigo_ies')
                 ->references('id')
                 ->on('modules.educacenso_ies');


### PR DESCRIPTION
A coluna `pmieducar.escola.codigo_lingua_indigena` é um array de inteiros e o Laravel não está apto a criar uma chave estrangeira para um array.

Por hora será removido a fim de permitir a atualização da versão 2.1 para 2.2, porém o problema deverá ser contornado de outra forma.