### PR TITLE
[2.2] Atualiza o CI para fazer teste do uso de Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
           - $HOME/.composer/cache
 
       before_script:
-        - git clone https://github.com/portabilis/i-educar-reports-package.git ieducar/modules/Reports
+        - git clone https://github.com/portabilis/i-educar-reports-package.git -b 2.2 ieducar/modules/Reports
 
       script:
         - docker-compose up -d --build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,45 @@
-language: php
+matrix:
 
-sudo: required
+  include:
 
-dist: xenial
+    - language: php
 
-php:
-  - '7.1'
-  - '7.2'
-  - '7.3'
+      php:
+        - '7.1'
+        - '7.2'
+        - '7.3'
 
-services:
-  - docker
+      sudo: required
 
-addons:
-  postgresql: '9.5'
-  chrome: stable
+      dist: xenial
 
-cache:
-  directories:
-    - $HOME/.composer/cache
+      addons:
+        postgresql: '9.5'
+        chrome: stable
 
-before_script:
-  - composer new-install
-  - php artisan dusk:chrome-driver
-  - vendor/laravel/dusk/bin/chromedriver-linux > /dev/null 2>&1 &
-  - php artisan serve > /dev/null 2>&1 &
+      cache:
+        directories:
+          - $HOME/.composer/cache
 
-script:
-  - vendor/bin/phpunit
-  - php artisan dusk
-  - docker-compose build
+      before_script:
+        - composer new-install
+        - php artisan dusk:chrome-driver
+        - vendor/laravel/dusk/bin/chromedriver-linux > /dev/null 2>&1 &
+        - php artisan serve > /dev/null 2>&1 &
 
-env:
-  global:
-    - APP_URL=http://localhost:8000
-    - APP_ENV=testing
-    - DB_CONNECTION=pgsql
-    - DB_HOST=localhost
-    - DB_PORT=5432
-    - DB_DATABASE=travis
-    - DB_USERNAME=postgres
-    - DB_PASSWORD=
-    - API_ACCESS_KEY=ieducar-access-key
-    - API_SECRET_KEY=ieducar-secret-key
+      script:
+        - vendor/bin/phpunit
+        - php artisan dusk
+
+      env:
+        global:
+          - APP_URL=http://localhost:8000
+          - APP_ENV=testing
+          - DB_CONNECTION=pgsql
+          - DB_HOST=localhost
+          - DB_PORT=5432
+          - DB_DATABASE=travis
+          - DB_USERNAME=postgres
+          - DB_PASSWORD=
+          - API_ACCESS_KEY=ieducar-access-key
+          - API_SECRET_KEY=ieducar-secret-key

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,14 @@ matrix:
         directories:
           - $HOME/.composer/cache
 
+      before_script:
+        - git clone https://github.com/portabilis/i-educar-reports-package.git ieducar/modules/Reports
+
       script:
-        - docker-compose build
-        - docker-compose up -d
+        - docker-compose up -d --build
         - docker-compose exec php composer new-install
+        - docker-compose exec php artisan reports:install
+        - docker-compose exec php vendor/bin/phpunit
 
     - language: php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ php:
   - '7.2'
   - '7.3'
 
+services:
+  - docker
+
 addons:
   postgresql: '9.5'
   chrome: stable
@@ -26,6 +29,7 @@ before_script:
 script:
   - vendor/bin/phpunit
   - php artisan dusk
+  - docker-compose build
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,101 @@ matrix:
 
   include:
 
+    - language: generic
+
+      services:
+        - docker
+
+      cache:
+        directories:
+          - $HOME/.composer/cache
+
+      script:
+        - docker-compose build
+        - docker-compose up -d
+        - docker-compose exec php composer new-install
+
     - language: php
 
       php:
         - '7.1'
+
+      sudo: required
+
+      dist: xenial
+
+      addons:
+        postgresql: '9.5'
+        chrome: stable
+
+      cache:
+        directories:
+          - $HOME/.composer/cache
+
+      before_script:
+        - composer new-install
+        - php artisan dusk:chrome-driver
+        - vendor/laravel/dusk/bin/chromedriver-linux > /dev/null 2>&1 &
+        - php artisan serve > /dev/null 2>&1 &
+
+      script:
+        - vendor/bin/phpunit
+        - php artisan dusk
+
+      env:
+        - APP_URL=http://localhost:8000
+        - APP_ENV=testing
+        - DB_CONNECTION=pgsql
+        - DB_HOST=localhost
+        - DB_PORT=5432
+        - DB_DATABASE=travis
+        - DB_USERNAME=postgres
+        - DB_PASSWORD=
+        - API_ACCESS_KEY=ieducar-access-key
+        - API_SECRET_KEY=ieducar-secret-key
+
+    - language: php
+
+      php:
         - '7.2'
+
+      sudo: required
+
+      dist: xenial
+
+      addons:
+        postgresql: '9.5'
+        chrome: stable
+
+      cache:
+        directories:
+          - $HOME/.composer/cache
+
+      before_script:
+        - composer new-install
+        - php artisan dusk:chrome-driver
+        - vendor/laravel/dusk/bin/chromedriver-linux > /dev/null 2>&1 &
+        - php artisan serve > /dev/null 2>&1 &
+
+      script:
+        - vendor/bin/phpunit
+        - php artisan dusk
+
+      env:
+        - APP_URL=http://localhost:8000
+        - APP_ENV=testing
+        - DB_CONNECTION=pgsql
+        - DB_HOST=localhost
+        - DB_PORT=5432
+        - DB_DATABASE=travis
+        - DB_USERNAME=postgres
+        - DB_PASSWORD=
+        - API_ACCESS_KEY=ieducar-access-key
+        - API_SECRET_KEY=ieducar-secret-key
+
+    - language: php
+
+      php:
         - '7.3'
 
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ sudo: required
 dist: xenial
 
 php:
-  - 7.1
-  - 7.2
-  - 7.3
+  - '7.1'
+  - '7.2'
+  - '7.3'
 
 addons:
-  postgresql: 9.5
+  postgresql: '9.5'
   chrome: stable
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,13 @@ matrix:
         - php artisan dusk
 
       env:
-        global:
-          - APP_URL=http://localhost:8000
-          - APP_ENV=testing
-          - DB_CONNECTION=pgsql
-          - DB_HOST=localhost
-          - DB_PORT=5432
-          - DB_DATABASE=travis
-          - DB_USERNAME=postgres
-          - DB_PASSWORD=
-          - API_ACCESS_KEY=ieducar-access-key
-          - API_SECRET_KEY=ieducar-secret-key
+        - APP_URL=http://localhost:8000
+        - APP_ENV=testing
+        - DB_CONNECTION=pgsql
+        - DB_HOST=localhost
+        - DB_PORT=5432
+        - DB_DATABASE=travis
+        - DB_USERNAME=postgres
+        - DB_PASSWORD=
+        - API_ACCESS_KEY=ieducar-access-key
+        - API_SECRET_KEY=ieducar-secret-key


### PR DESCRIPTION
Permite que o Travis faça uma instalação completa, incluíndo relatórios, do i-Educar para simular uma instalação utilizando Docker para desenvolvimento.