### PR TITLE
[2.1] Suporte ao Apache HTTP Server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ matrix:
       before_script:
         - composer new-install
         - php artisan dusk:chrome-driver
-        - vendor/laravel/dusk/bin/chromedriver-linux > /dev/null 2>&1 &
         - php artisan serve > /dev/null 2>&1 &
 
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
 
       before_script:
         - composer new-install
-        - php artisan dusk:chrome-driver
+        - php artisan dusk:chrome-driver 74
         - php artisan serve > /dev/null 2>&1 &
 
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,10 @@ matrix:
       dist: xenial
 
       php:
-        - 7.1
-        - 7.2
+        - '7.2'
 
       addons:
-        postgresql: 9.5
+        postgresql: '9.5'
         chrome: stable
 
       env:

--- a/docker/httpd/Dockerfile
+++ b/docker/httpd/Dockerfile
@@ -1,0 +1,7 @@
+FROM httpd
+
+MAINTAINER Portabilis
+
+RUN apt-get update -y
+
+RUN echo "Include /usr/local/apache2/conf/default.conf" >> /usr/local/apache2/conf/httpd.conf

--- a/docker/httpd/default.conf
+++ b/docker/httpd/default.conf
@@ -1,0 +1,31 @@
+ServerName localhost
+
+LoadModule deflate_module /usr/local/apache2/modules/mod_deflate.so
+LoadModule proxy_module /usr/local/apache2/modules/mod_proxy.so
+LoadModule proxy_fcgi_module /usr/local/apache2/modules/mod_proxy_fcgi.so
+LoadModule rewrite_module modules/mod_rewrite.so
+
+<VirtualHost *:80>
+
+    DocumentRoot /var/www/ieducar/public/
+
+    RewriteEngine On
+
+    LogLevel alert rewrite:trace3
+
+    RewriteRule ^/intranet/?$ /intranet/index.php [R]
+
+    RewriteRule ^/module/(.*)/(imagens|scripts|styles)/(.*)$ /intranet/$2/$3 [PT]
+
+    RewriteRule ^(/intranet.*\.php|/modules.*\.php|/module/) /index.php$1 [PT]
+
+    ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://php:9000/var/www/ieducar/public/$1
+
+    <Directory /var/www/ieducar/public/>
+        DirectoryIndex index.php
+        Options +FollowSymLinks -Indexes
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+</VirtualHost>

--- a/docker/httpd/default.conf
+++ b/docker/httpd/default.conf
@@ -11,8 +11,6 @@ LoadModule rewrite_module modules/mod_rewrite.so
 
     RewriteEngine On
 
-    LogLevel alert rewrite:trace3
-
     RewriteRule ^/intranet/?$ /intranet/index.php [R]
 
     RewriteRule ^/module/(.*)/(imagens|scripts|styles)/(.*)$ /intranet/$2/$3 [PT]

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx
 
-MAINTAINER Eder Soares
+LABEL maintainer="Portabilis <contato@portabilis.com.br>"
 
 RUN apt-get update -y
 


### PR DESCRIPTION
Implementa suporte ao Apache HTTP Server como servidor web principal para rodar o i-Educar.

Ele pode ser utilizado em conjunto com o Nginx, mas por hora, será implementado de forma a se utilizar um ou outro.

Para quem quiser o utilizar o Apache via Docker, basta adicionar ao ser arquivo `docker-compose.override.yml` o seguinte trecho

```yml
# docker-compose.override.yml

  httpd:
    container_name: ieducar-httpd
    build: docker/httpd
    links:
      - php
    ports:
      - 80
    working_dir: /var/www/ieducar
    volumes:
      - ./:/var/www/ieducar
      - ./docker/httpd/default.conf:/usr/local/apache2/conf/default.conf
```

Mapeie a porta, ou execute `docker-compose port httpd 80` para saber qual porta o Apache está respondendo.

Para quem quiser utilizar diretamente no servidor precisa definir um arquivo de configuração similar a este: https://github.com/edersoares/i-educar/blob/1d0fdf9e5a6707fdd98753c30fa0b9a46b33bece/docker/httpd/default.conf.

Close https://github.com/portabilis/i-educar/issues/484.