### PR TITLE
[2.1] Inverte a ordem dos comandos de instalação

### DIFF
--- a/public/js/install.js
+++ b/public/js/install.js
@@ -92,12 +92,12 @@ if (installButton) {
                 command: 'database',
                 description: 'Inicializando banco de dados'
             },{
+              command: 'migrate',
+              description: 'Executando migrações'
+            }, {
               command: 'password',
               description: 'Definindo senha do admin',
               extra: password
-            }, {
-                command: 'migrate',
-                description: 'Executando migrações'
             }, {
                 command: 'reports',
                 description: 'Instalando relatórios'


### PR DESCRIPTION
Corrige problema discutido no fórum https://forum.ieducar.org/t/duvidas-ao-instalar-o-i-educar-no-ubuntu-18-04/594/9.

É necessário rodar todas as migrations antes de definir a senha do administrador.