### PR TITLE
[2.1] Utiliza a versão 74 do Chrome driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ matrix:
 
       before_script:
         - composer new-install
-        - php artisan dusk:chrome-driver
-        - vendor/laravel/dusk/bin/chromedriver-linux > /dev/null 2>&1 &
+        - php artisan dusk:chrome-driver 74
         - php artisan serve > /dev/null 2>&1 &
 
       script:


### PR DESCRIPTION
Instala a versão 74 do Chrome driver que permite executar os testes com Laravel Dusk sem erros.