### PR TITLE
[2.2] Corrige rollback das migrations

### DIFF
--- a/database/migrations/2019_01_01_200000_add_foreign_keys_in_employee_graduations_table.php
+++ b/database/migrations/2019_01_01_200000_add_foreign_keys_in_employee_graduations_table.php
@@ -28,9 +28,9 @@ class AddForeignKeysInEmployeeGraduationsTable extends Migration
     public function down()
     {
         Schema::table('employee_graduations', function (Blueprint $table) {
-            $table->dropForeign('course_id');
-            $table->dropForeign('college_id');
-            $table->dropForeign('discipline_id');
+            $table->dropForeign(['course_id']);
+            $table->dropForeign(['college_id']);
+            $table->dropForeign(['discipline_id']);
         });
     }
 }

--- a/database/migrations/2019_01_01_200000_add_foreign_keys_in_school_managers_table.php
+++ b/database/migrations/2019_01_01_200000_add_foreign_keys_in_school_managers_table.php
@@ -29,10 +29,10 @@ class AddForeignKeysInSchoolManagersTable extends Migration
     public function down()
     {
         Schema::table('school_managers', function (Blueprint $table) {
-            $table->dropForeign('school_id');
-            $table->dropForeign('role_id');
-            $table->dropForeign('access_criteria_id');
-            $table->dropForeign('link_type_id');
+            $table->dropForeign(['school_id']);
+            $table->dropForeign(['role_id']);
+            $table->dropForeign(['access_criteria_id']);
+            $table->dropForeign(['link_type_id']);
         });
     }
 }

--- a/database/migrations/legacy/2019_01_01_200000_add_foreign_keys_on_pmieducar_menu_tipo_usuario_table.php
+++ b/database/migrations/legacy/2019_01_01_200000_add_foreign_keys_on_pmieducar_menu_tipo_usuario_table.php
@@ -32,8 +32,8 @@ class AddForeignKeysOnPmieducarMenuTipoUsuarioTable extends Migration
     public function down()
     {
         Schema::table('pmieducar.menu_tipo_usuario', function (Blueprint $table) {
-            $table->dropForeign('ref_cod_tipo_usuario');
-            $table->dropForeign('menu_id');
+            $table->dropForeign(['ref_cod_tipo_usuario']);
+            $table->dropForeign(['menu_id']);
         });
     }
 }


### PR DESCRIPTION
Ao executar `php artisan migrate:rollback` erros ao excluir chave estrangeira era apresentados, faz a correção. 