### PR TITLE
Correção da query de buscar endereço pois esta buscando distrito errado

### DIFF
--- a/ieducar/modules/Api/Views/EnderecoController.php
+++ b/ieducar/modules/Api/Views/EnderecoController.php
@@ -33,7 +33,7 @@ class EnderecoController extends ApiCoreController
                 INNER JOIN public.bairro b ON b.idbai = c.idbai
                 INNER JOIN public.logradouro l ON l.idlog = c.idlog
                 INNER JOIN urbano.tipo_logradouro t ON t.idtlog = l.idtlog
-                INNER JOIN public.distrito d ON d.idmun = l.idmun
+                INNER JOIN public.distrito d ON d.iddis = b.iddis
                 INNER JOIN public.municipio m ON m.idmun = l.idmun
                                              AND m.idmun = d.idmun
                 INNER JOIN public.uf u ON u.sigla_uf = m.sigla_uf


### PR DESCRIPTION
## Descrição
Correção da query de buscar endereço pois esta buscando distrito errado

## Contexto e motivação
Quando digita um cep e o município tem mais de um distrito está buscando o distrito errado.

## Tipos de alterações
- ✅ Bug fix (Não quebra outras funcionalidades)

## Checklist:
<!--- Verifique todos os pontos. -->
<!--- Novamente, remova todas as linhas que não foram aplicadas. -->
<!--- Pull Requests que não atenderem todos os [REQUIRED] provavelmente não serão aceitos -->

- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue a PSR2. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**
- x Minhas alterações necessitam de alteração na documentação e já foram feitas.
- x Criei testes automatizados que cobrem minhas alterações.
