### PR TITLE
[2.2] Atualiza OpenJDK no Dockerfile

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -28,7 +28,7 @@ RUN docker-php-ext-enable redis
 RUN rm -rf /tmp/pear
 
 RUN mkdir -p /usr/share/man/man1
-RUN apt-get install -y openjdk-8-jre
+RUN apt-get install -y default-jdk
 
 RUN docker-php-ext-install bcmath
 


### PR DESCRIPTION
Algumas pessoas apresentaram problemas na instalação do Java durante o processo de build do container, com isso para resolver o erro podemos alterar o **openjdk-8-jre** por **default-jdk** que a instalação do java irá ocorrer de forma continua sem problema algum e com isso a versão do Java instalada será a 11.