### PR TITLE
[2.2] Remove hash de verificação do Composer no Dockerfile

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -47,10 +47,7 @@ RUN apt-get install -y jq git
 
 RUN ln -s /var/www/ieducar/artisan /usr/local/bin/artisan
 
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php -r "if (hash_file('sha384', 'composer-setup.php') === '48e3236262b34d30969dca3c37281b3b4bbe3221bda826ac6a9a62d6444cdb0dcd0615698a5cbe587c3f0fe57a54d8f5') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer
-RUN php -r "unlink('composer-setup.php');"
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 


### PR DESCRIPTION
**DESCRIÇÃO:**

Não faz sentido verificar se a hash do arquivo do composer baixado é igual a uma hash fixa dentro do workflow devido a atualizações no composer quebrarem essa etapa da do processo.

**AMBIENTE:**

- Plataforma utilizada (Docker, instalação direta)
