### PR TITLE
[2.2] Permite utilizar o instalador para fazer o upgrade de versão

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -107,7 +107,7 @@ if ($isInstalled) {
             crossorigin="anonymous">
         <link rel="stylesheet"
             href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|PT+Mono">
-        <link rel="stylesheet" href="css/install.css">
+        <link rel="stylesheet" href="css/install.css?version=<?php echo $currIeducarVersion ?>">
     </head>
 
     <body>
@@ -335,6 +335,6 @@ chmod -R 777 <?= $path . "\n" ?>
         <script
             src="https://www.promisejs.org/polyfills/promise-7.0.4.min.js">
         </script>
-        <script src="js/install.js"></script>
+        <script src="js/install.js?version=<?php echo $currIeducarVersion ?>"></script>
     </body>
 </html>


### PR DESCRIPTION
Permite utilizar o instalador para fazer o upgrade da versão [2.1](https://github.com/portabilis/i-educar/tree/2.1) para a versão [2.2](https://github.com/portabilis/i-educar/tree/2.2).

- É necessário executar o comando `link` sempre que a atualização é feita.
- Foi adicionado a versão ao JavaScript e CSS carregados para que o cache do navegador não atrapalhe.

É necessário utilizar  a release [2.1.25](https://github.com/portabilis/i-educar/releases/tag/2.1.25-upgrade) para fazer o upgrade através do instalador.

Refs #658.