### PR TITLE
[2.2] Adiciona extensão pcntl a imagem PHP

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -55,3 +55,5 @@ COPY php.ini /usr/local/etc/php/php.ini
 
 COPY pdflib.so /usr/local/lib/php/extensions/no-debug-non-zts-20180731/pdflib.so
 RUN echo "extension=/usr/local/lib/php/extensions/no-debug-non-zts-20180731/pdflib.so" > /usr/local/etc/php/conf.d/pdflib.ini
+
+RUN docker-php-ext-install pcntl


### PR DESCRIPTION
O Laravel Dusk teve uma dependência adicionada e foi necessário adicionar a extensão `pcntl` a imagem PHP do Docker.