### PR TITLE
[2.2] Adiciona coluna esquecida

### DIFF
--- a/database/migrations/2019_10_02_095426_adiciona_coluna_historico_do_tipo_json_na_tabela_candidato_reserva_de_vagas.php
+++ b/database/migrations/2019_10_02_095426_adiciona_coluna_historico_do_tipo_json_na_tabela_candidato_reserva_de_vagas.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AdicionaColunaHistoricoDoTipoJsonNaTabelaCandidatoReservaDeVagas extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pmieducar.candidato_reserva_vaga', function (Blueprint $table) {
+            $table->json('historico')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pmieducar.candidato_reserva_vaga', function (Blueprint $table) {
+            $table->dropColumn('historico');
+        });
+    }
+}


### PR DESCRIPTION
A coluna `historico` é necessária na tabela `pmieducar.candidato_reserva_vaga` e estava ocasionando o erro ao fazer uma nova matrícula.

Origem: https://forum.ieducar.org/t/erro-ao-matricular-aluno/846.