### PR TITLE
[2.3] Reestrutura a auditoria do banco de dados 

### DIFF
--- a/app/Listeners/ConfigureAuthenticatedUserForAudit.php
+++ b/app/Listeners/ConfigureAuthenticatedUserForAudit.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Database\Connection;
+
+class ConfigureAuthenticatedUserForAudit
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @param Connection $connection
+     */
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * Set context data for audit log.
+     *
+     * @param int    $id
+     * @param string $name
+     *
+     * @return void
+     */
+    private function setContext($id, $name)
+    {
+        $pdo = $this->connection->getPdo();
+
+        $enabled = config('audit.enabled', true) ? 'true' : 'false';
+
+        $context = json_encode([
+            'user_id' => $id,
+            'user_name' => $name,
+        ]);
+
+        $pdo->exec("SET \"audit.enabled\" = {$enabled};");
+        $pdo->exec("SET \"audit.context\" = '{$context}';");
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param object $event
+     *
+     * @return void
+     */
+    public function handle($event)
+    {
+        $this->setContext($event->user->id, $event->user->name);
+    }
+}

--- a/app/Listeners/ConfigureAuthenticatedUserForAudit.php
+++ b/app/Listeners/ConfigureAuthenticatedUserForAudit.php
@@ -3,6 +3,7 @@
 namespace App\Listeners;
 
 use Illuminate\Database\Connection;
+use Illuminate\Http\Request;
 
 class ConfigureAuthenticatedUserForAudit
 {
@@ -12,11 +13,18 @@ class ConfigureAuthenticatedUserForAudit
     private $connection;
 
     /**
-     * @param Connection $connection
+     * @var Request
      */
-    public function __construct(Connection $connection)
+    private $request;
+
+    /**
+     * @param Connection $connection
+     * @param Request    $request
+     */
+    public function __construct(Connection $connection, Request $request)
     {
         $this->connection = $connection;
+        $this->request = $request;
     }
 
     /**
@@ -36,6 +44,7 @@ class ConfigureAuthenticatedUserForAudit
         $context = json_encode([
             'user_id' => $id,
             'user_name' => $name,
+            'origin' => $this->request->fullUrl(),
         ]);
 
         $pdo->exec("SET \"audit.enabled\" = {$enabled};");

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Events\TransferEvent;
 use App\Listeners\AuthenticatedUser;
+use App\Listeners\ConfigureAuthenticatedUserForAudit;
 use App\Listeners\TransferNotificationListener;
 use App\Models\SchoolManager;
 use App\Observers\SchoolManagerObserver;
@@ -37,7 +38,8 @@ class EventServiceProvider extends ServiceProvider
             NotificationWhenResetPassword::class,
         ],
         Authenticated::class => [
-            AuthenticatedUser::class
+            AuthenticatedUser::class,
+            ConfigureAuthenticatedUserForAudit::class,
         ],
         RegistrationEvent::class => [
             CopyTransferDataListener::class,

--- a/app/Support/Database/AuditTrigger.php
+++ b/app/Support/Database/AuditTrigger.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Support\Database;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+trait AuditTrigger
+{
+    /**
+     * Return not audited tables.
+     *
+     * @return array
+     */
+    public function getSkippedTables()
+    {
+        return config('audit.skip', [
+            'audit',
+            'public.audit',
+        ]);
+    }
+
+    /**
+     * Return audited tables.
+     *
+     * @return array
+     */
+    public function getAuditedTables()
+    {
+        $tables = DB::connection()->getDoctrineSchemaManager()->listTableNames();
+
+        return collect($tables)->sort()->reject(function ($table) {
+            return in_array($table, $this->getSkippedTables());
+        })->values()->toArray();
+    }
+
+    /**
+     * Return create audit trigger SQL to the table.
+     *
+     * @param string $table
+     *
+     * @return string
+     */
+    public function getSqlForCreateAuditTrigger($table)
+    {
+        $trigger = Str::slug($table, '_') . '_audit';
+
+        return <<<SQL
+create trigger {$trigger}
+after insert or update or delete on {$table}
+for each row execute procedure audit();
+SQL;
+    }
+
+    /**
+     * Return drop audit trigger SQL to the table.
+     *
+     * @param string $table
+     *
+     * @return string
+     */
+    public function getSqlForDropAuditTrigger($table)
+    {
+        $trigger = Str::slug($table, '_') . '_audit';
+
+        return <<<SQL
+drop trigger if exists {$trigger} on {$table};
+SQL;
+    }
+
+    /**
+     * Create audit trigger for table.
+     *
+     * @param string $table
+     *
+     * @return void
+     */
+    public function createAuditTrigger($table)
+    {
+        DB::unprepared(
+            $this->getSqlForCreateAuditTrigger($table)
+        );
+    }
+
+    /**
+     * Drop audit trigger from table.
+     *
+     * @param string $table
+     *
+     * @return void
+     */
+    public function dropAuditTrigger($table)
+    {
+        DB::unprepared(
+            $this->getSqlForDropAuditTrigger($table)
+        );
+    }
+
+    /**
+     * Create all audit triggers.
+     *
+     * @return void
+     */
+    public function createAuditTriggers()
+    {
+        foreach ($this->getAuditedTables() as $table) {
+            $this->createAuditTrigger($table);
+        }
+    }
+
+    /**
+     * Drop all audit triggers.
+     *
+     * @return void
+     */
+    public function dropAuditTriggers()
+    {
+        foreach ($this->getAuditedTables() as $table) {
+            $this->dropAuditTrigger($table);
+        }
+    }
+}

--- a/app/Support/Database/AuditTrigger.php
+++ b/app/Support/Database/AuditTrigger.php
@@ -48,7 +48,7 @@ trait AuditTrigger
         return <<<SQL
 create trigger {$trigger}
 after insert or update or delete on {$table}
-for each row execute procedure audit();
+for each row execute procedure public.audit();
 SQL;
     }
 

--- a/database/migrations/2019_12_01_100000_audit_functions.php
+++ b/database/migrations/2019_12_01_100000_audit_functions.php
@@ -1,0 +1,136 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class AuditFunctions extends Migration
+{
+    /**
+     * Return SQL to drop a function.
+     *
+     * @param string $function
+     *
+     * @return string
+     */
+    private function getSqlForDropFunction($function)
+    {
+        return "drop function if exists {$function}();";
+    }
+
+    /**
+     * Return SQL to create audit context function.
+     *
+     * @return string
+     */
+    private function getSqlForAuditContextFunction()
+    {
+        return <<<SQL
+create function audit_context()
+returns json as 
+\$function$
+begin 
+	begin 
+		return current_setting('audit.context');
+	exception when others then 
+		return json_build_object('user_id', 0, 'user_name', session_user);
+	end;
+end;
+\$function$
+language plpgsql;
+SQL;
+    }
+
+    /**
+     * Return SQL to create audit enabled function.
+     *
+     * @return string
+     */
+    private function getSqlForAuditEnabledFunction()
+    {
+        return <<<SQL
+create function audit_enabled()
+returns boolean as 
+\$function$
+begin 
+	begin 
+		return current_setting('audit.enabled');
+	exception when others then 
+		return false;
+	end;
+end;
+\$function$
+language plpgsql;
+SQL;
+    }
+
+    /**
+     * Return SQL to create audit function.
+     *
+     * @return string
+     */
+    private function getSqlForAuditFunction()
+    {
+        return <<<SQL
+create function audit() 
+returns trigger as
+\$function$
+begin 
+	if (audit_enabled() = false) then 
+		return null;
+	end if;
+
+	if (TG_OP = 'DELETE') then 
+		insert into audit ("date", "schema", "table", "context", "before", "after")
+		values (now(), TG_TABLE_SCHEMA::text, TG_TABLE_NAME::text, audit_context(), to_json(old.*), null);
+
+		return old;
+	end if;
+
+	if (TG_OP = 'UPDATE') then 
+		insert into audit ("date", "schema", "table", "context", "before", "after")
+		values (now(), TG_TABLE_SCHEMA::text, TG_TABLE_NAME::text, audit_context(), to_json(old.*), to_json(new.*));
+
+		return old;
+	end if;
+
+	if (TG_OP = 'INSERT') then 
+		insert into audit ("date", "schema", "table", "context", "before", "after")
+		values (now(), TG_TABLE_SCHEMA::text, TG_TABLE_NAME::text, audit_context(), null, to_json(new.*));
+
+		return old;
+	end if;
+
+	return null;
+end;
+\$function$
+language plpgsql;
+SQL;
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::unprepared($this->getSqlForDropFunction('audit'));
+        DB::unprepared($this->getSqlForDropFunction('audit_context'));
+        DB::unprepared($this->getSqlForDropFunction('audit_enabled'));
+        DB::unprepared($this->getSqlForAuditContextFunction());
+        DB::unprepared($this->getSqlForAuditEnabledFunction());
+        DB::unprepared($this->getSqlForAuditFunction());
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::unprepared($this->getSqlForDropFunction('audit'));
+        DB::unprepared($this->getSqlForDropFunction('audit_context'));
+        DB::unprepared($this->getSqlForDropFunction('audit_enabled'));
+    }
+}

--- a/database/migrations/2019_12_01_100000_audit_functions.php
+++ b/database/migrations/2019_12_01_100000_audit_functions.php
@@ -55,7 +55,7 @@ begin
 	begin 
 		return current_setting('audit.enabled');
 	exception when others then 
-		return false;
+		return true;
 	end;
 end;
 \$function$

--- a/database/migrations/2019_12_01_100000_audit_functions.php
+++ b/database/migrations/2019_12_01_100000_audit_functions.php
@@ -71,7 +71,7 @@ SQL;
     private function getSqlForAuditFunction()
     {
         return <<<SQL
-create function audit() 
+create function public.audit() 
 returns trigger as
 \$function$
 begin 

--- a/database/migrations/2019_12_01_100000_create_audit_table.php
+++ b/database/migrations/2019_12_01_100000_create_audit_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateAuditTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('audit', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->json('context')->nullable();
+            $table->json('before')->nullable();
+            $table->json('after')->nullable();
+            $table->string('schema');
+            $table->string('table');
+            $table->timestamp('date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('audit');
+    }
+}

--- a/database/migrations/2019_12_01_200000_audit_triggers.php
+++ b/database/migrations/2019_12_01_200000_audit_triggers.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Support\Database\AuditTrigger;
+use Illuminate\Database\Migrations\Migration;
+
+class AuditTriggers extends Migration
+{
+    use AuditTrigger;
+
+    /**
+     * @var bool
+     */
+    public $withinTransaction = false;
+
+    /**
+     * Return not audited tables.
+     *
+     * @return array
+     */
+    public function getSkippedTables()
+    {
+        return config('audit.skip', [
+            'audit',
+            'public.audit',
+            'modules.auditoria',
+            'modules.auditoria_geral',
+        ]);
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->createAuditTriggers();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->dropAuditTriggers();
+    }
+}


### PR DESCRIPTION
## Auditoria

Atualmente o i-Educar não possui uma solução completa para o sistema de auditoria do banco de dados, sendo feita a auditoria através da classe `clsModulesAuditoriaGeral` para algumas tabelas e implementado via aplicação.

Essa abordagem faz com que seja necessário implementar individualmente a auditoria para cada tabela/entidade o que torna oneroso e duplicado o trabalho.

Desta forma, este PR prevê uma implementação a nível do banco de dados através do uso de triggers para logar as devidas alterações e o uso de variáveis o contexto (usuário e outras informações).

As triggers serão criadas para todas as tabelas do banco de dados exceto a tabela `audit` para evitar recursividade e as tabelas `modules.auditoria` e `modules.auditoria_geral` que compunham o antigo sistema de auditoria.

Este PR também visa, deixar o i-Educar mais próximo a alcançar os requisitos da [LGPD](http://www.planalto.gov.br/ccivil_03/_ato2015-2018/2018/lei/L13709.htm).

### Pontos importantes

#### Desabilitar a auditoria

Será possível desabilitar a auditoria, modificando a configuração `audit.enabled` para `false`.

#### Aumento considerável do banco de dados

O banco de dados passará a crescer mais rapidamente, pois tudo será registrado na tabela `audit`. É de extrema importância monitorar o crescimento da tabela.

### Próximos passos

- [ ] Tela para auditar as modificações feitas nos registros do i-Educar.
- [ ] Remover referências a classe `clsModulesAuditoriaGeral`.
- [ ] Remover tabelas do banco de dados `modules.auditoria` e `modules.auditoria_geral`.
- [ ] Remove triggers antigas de auditoria.