### PR TITLE
Adiciona schema da tabela na migration

### DIFF
--- a/database/migrations/2020_02_16_100000_add_primary_column_in_configuracoes_gerais_table.php
+++ b/database/migrations/2020_02_16_100000_add_primary_column_in_configuracoes_gerais_table.php
@@ -13,7 +13,7 @@ class AddPrimaryColumnInConfiguracoesGeraisTable extends Migration
      */
     public function up()
     {
-        Schema::table('configuracoes_gerais', function (Blueprint $table) {
+        Schema::table('pmieducar.configuracoes_gerais', function (Blueprint $table) {
             $table->primary('ref_cod_instituicao');
         });
     }
@@ -25,7 +25,7 @@ class AddPrimaryColumnInConfiguracoesGeraisTable extends Migration
      */
     public function down()
     {
-        Schema::table('configuracoes_gerais', function (Blueprint $table) {
+        Schema::table('pmieducar.configuracoes_gerais', function (Blueprint $table) {
             $table->dropPrimary('ref_cod_instituicao');
         });
     }


### PR DESCRIPTION
Adiciona o schema da tabela na migration.

A falta disso está gerando o erro reportado no fórum
https://forum.ieducar.org/t/erro-na-instalacao-i-educar-2-2-20/950