### PR TITLE
Altera o UrlPresigner para permitir uso local usando filesystems.default

### DIFF
--- a/app/Services/UrlPresigner.php
+++ b/app/Services/UrlPresigner.php
@@ -8,13 +8,13 @@ class UrlPresigner
 {
     public function getPresignedUrl(string $url) : string
     {
-        switch (config('filesystems.cloud')) {
+        switch (config('filesystems.default')) {
             case 'local':
                 return $url;
             case 's3':
                 return (new S3UrlPresigner())->getPresignedUrl($url);
             default:
-                throw new Exception('Method UrlPresigner::getPresignedUrl() not implemented for cloud filesystem: '. config('filesystems.cloud'));
+                throw new Exception('Method UrlPresigner::getPresignedUrl() not implemented for cloud filesystem: '. config('filesystems.default'));
         }
     }
 }


### PR DESCRIPTION
Olá e obrigado por nos ajudar a tornar o i-Educar um projeto mais estável. Para abrir um pull request use o template abaixo:

**DESCRIÇÃO:**

   O arquivo alterado na release 2.3.1 ainda precisou de ajustes, uma vez que o .env não mais contém a variável FILESYSTEM_CLOUD, que foi substituída por FILESYSTEM_DRIVER e como  padrão **default.cloud** devolve **s3** e não **local** como esperado, causando exceção na função.
A alteração ajuda na padronização do sistema pois a variável FILESYSTEM_DRIVER pode receber **local**, **minio** ou **s3** conforme o sistema de armazenamento utilizado pelo usuário.

**AMBIENTE:**

Descreva o ambiente em que este pull request foi criado.

- Plataforma utilizada (Docker, instalação direta)
- Sistema operacional e versão (Ubuntu 20.04)
- Navegador e versão (Chrome 83
- Outros detalhes importantes
