### PR TITLE
[2.5] Corrige instalador

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -67,7 +67,7 @@ $host = $_SERVER['HTTP_HOST'] ?? '';
 $dbCheck = false;
 
 if ($envExists) {
-    Dotenv\Dotenv::create($rootDir)->load();
+    Dotenv\Dotenv::createImmutable($rootDir)->load();
     $dbCheck = $installer->checkDatabaseConnection();
     $isInstalled = $installer->isInstalled();
 }


### PR DESCRIPTION
Após atualizar a versão para o Laravel 7, a biblioteca [Dotenv](https://github.com/vlucas/phpdotenv) teve seus construtor modificado sendo necessário fazer a alteração da invocação do método que carrega o arquivo `.env`.