### PR TITLE
[2.5] Migra ID do Brasil nos estados brasileiros

### DIFF
--- a/database/migrations/2021_01_22_000000_migrate_coutry_id_in_states_table.php
+++ b/database/migrations/2021_01_22_000000_migrate_coutry_id_in_states_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\Country;
+use App\Models\State;
+use Illuminate\Database\Migrations\Migration;
+
+class MigrateCoutryIdInStatesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $brazil = Country::query()->where('ibge_code', 76)->first();
+
+        if (empty($brazil)) {
+            return;
+        }
+
+        State::query()->whereIn('ibge_code', [
+            12, 27, 13, 16, 29, 23, 53, 32, 52, 21, 31, 50, 51, 15, 25, 26, 22, 41, 33, 24, 11, 14, 43, 42, 28, 35, 17,
+        ])->update([
+            'country_id' => $brazil->getKey(),
+        ]);
+    }
+}


### PR DESCRIPTION
Migra ID do Brasil nos estados brasileiros.

Complemento do PR https://github.com/portabilis/i-educar/pull/743.