### PR TITLE
[2.5] Prepara o i-Educar para upgrade do banco de dados

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Software livre de gestão escolar",
     "type": "project",
     "license": "GPL-2.0-or-later",
-    "version": "2.5.3",
+    "version": "2.5.4",
     "keywords": [
         "Portabilis",
         "i-Educar"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4daa13a1407d6793c24485b318cb3285",
+    "content-hash": "6407b2eaac98bf49429a53e9f2509b2b",
     "packages": [
         {
             "name": "asm89/stack-cors",
-            "version": "v2.0.2",
+            "version": "v2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/asm89/stack-cors.git",
-                "reference": "8d8f88b3b3830916be94292c1fbce84433efb1aa"
+                "reference": "9cb795bf30988e8c96dd3c40623c48a877bc6714"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/asm89/stack-cors/zipball/8d8f88b3b3830916be94292c1fbce84433efb1aa",
-                "reference": "8d8f88b3b3830916be94292c1fbce84433efb1aa",
+                "url": "https://api.github.com/repos/asm89/stack-cors/zipball/9cb795bf30988e8c96dd3c40623c48a877bc6714",
+                "reference": "9cb795bf30988e8c96dd3c40623c48a877bc6714",
                 "shasum": ""
             },
             "require": {
@@ -58,22 +58,22 @@
             ],
             "support": {
                 "issues": "https://github.com/asm89/stack-cors/issues",
-                "source": "https://github.com/asm89/stack-cors/tree/v2.0.2"
+                "source": "https://github.com/asm89/stack-cors/tree/v2.0.3"
             },
-            "time": "2020-10-29T16:03:21+00:00"
+            "time": "2021-03-11T06:42:03+00:00"
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.173.7",
+            "version": "3.174.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "854b9f827438d1d69df6550d9ada40deaa6d44fe"
+                "reference": "b481fd0dab83b9ed6eab35279e1a43e3a875c87e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/854b9f827438d1d69df6550d9ada40deaa6d44fe",
-                "reference": "854b9f827438d1d69df6550d9ada40deaa6d44fe",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b481fd0dab83b9ed6eab35279e1a43e3a875c87e",
+                "reference": "b481fd0dab83b9ed6eab35279e1a43e3a875c87e",
                 "shasum": ""
             },
             "require": {
@@ -81,9 +81,9 @@
                 "ext-pcre": "*",
                 "ext-simplexml": "*",
                 "guzzlehttp/guzzle": "^5.3.3|^6.2.1|^7.0",
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.4.1",
-                "mtdowling/jmespath.php": "^2.5",
+                "guzzlehttp/promises": "^1.4.0",
+                "guzzlehttp/psr7": "^1.7.0",
+                "mtdowling/jmespath.php": "^2.6",
                 "php": ">=5.5"
             },
             "require-dev": {
@@ -148,9 +148,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.173.7"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.174.1"
             },
-            "time": "2021-02-11T19:13:05+00:00"
+            "time": "2021-03-16T18:18:56+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -1579,16 +1579,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "60d379c243457e073cff02bc323a2a86cb355631"
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/60d379c243457e073cff02bc323a2a86cb355631",
-                "reference": "60d379c243457e073cff02bc323a2a86cb355631",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
                 "shasum": ""
             },
             "require": {
@@ -1628,9 +1628,9 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.4.0"
+                "source": "https://github.com/guzzle/promises/tree/1.4.1"
             },
-            "time": "2020-09-30T07:37:28+00:00"
+            "time": "2021-03-07T09:25:29+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -1709,16 +1709,16 @@
         },
         {
             "name": "honeybadger-io/honeybadger-laravel",
-            "version": "v3.4.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/honeybadger-io/honeybadger-laravel.git",
-                "reference": "22cca8a61563950cdcfe4da8b41270036bebe89d"
+                "reference": "6f450481025aea8077f8ddc392ca3c40ad8090e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/honeybadger-io/honeybadger-laravel/zipball/22cca8a61563950cdcfe4da8b41270036bebe89d",
-                "reference": "22cca8a61563950cdcfe4da8b41270036bebe89d",
+                "url": "https://api.github.com/repos/honeybadger-io/honeybadger-laravel/zipball/6f450481025aea8077f8ddc392ca3c40ad8090e8",
+                "reference": "6f450481025aea8077f8ddc392ca3c40ad8090e8",
                 "shasum": ""
             },
             "require": {
@@ -1775,25 +1775,26 @@
             ],
             "support": {
                 "issues": "https://github.com/honeybadger-io/honeybadger-laravel/issues",
-                "source": "https://github.com/honeybadger-io/honeybadger-laravel/tree/v3.4.0"
+                "source": "https://github.com/honeybadger-io/honeybadger-laravel/tree/v3.7.0"
             },
-            "time": "2020-12-17T17:29:34+00:00"
+            "time": "2021-03-09T16:49:25+00:00"
         },
         {
             "name": "honeybadger-io/honeybadger-php",
-            "version": "v2.3.0",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/honeybadger-io/honeybadger-php.git",
-                "reference": "217f018d2ea91fcea2132f3cf7ea17389f182b3f"
+                "reference": "e1384ac0ebcd7cb54742ba4a8ba4dabc4e168ee1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/honeybadger-io/honeybadger-php/zipball/217f018d2ea91fcea2132f3cf7ea17389f182b3f",
-                "reference": "217f018d2ea91fcea2132f3cf7ea17389f182b3f",
+                "url": "https://api.github.com/repos/honeybadger-io/honeybadger-php/zipball/e1384ac0ebcd7cb54742ba4a8ba4dabc4e168ee1",
+                "reference": "e1384ac0ebcd7cb54742ba4a8ba4dabc4e168ee1",
                 "shasum": ""
             },
             "require": {
+                "ext-json": "*",
                 "guzzlehttp/guzzle": "^6.3|^7.0.1",
                 "monolog/monolog": "^2.0",
                 "php": "^7.2|^8.0",
@@ -1806,6 +1807,11 @@
                 "phpunit/phpunit": "^8.5|^9.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Honeybadger\\": "src"
@@ -1836,9 +1842,9 @@
             ],
             "support": {
                 "issues": "https://github.com/honeybadger-io/honeybadger-php/issues",
-                "source": "https://github.com/honeybadger-io/honeybadger-php/tree/v2.3.0"
+                "source": "https://github.com/honeybadger-io/honeybadger-php/tree/v2.8.0"
             },
-            "time": "2020-11-29T17:45:04+00:00"
+            "time": "2021-03-15T23:12:15+00:00"
         },
         {
             "name": "intervention/image",
@@ -2155,16 +2161,16 @@
         },
         {
             "name": "laravel/tinker",
-            "version": "v2.6.0",
+            "version": "v2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/tinker.git",
-                "reference": "daae1c43f1300fe88c05d83db6f3d8f76677ad88"
+                "reference": "04ad32c1a3328081097a181875733fa51f402083"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/tinker/zipball/daae1c43f1300fe88c05d83db6f3d8f76677ad88",
-                "reference": "daae1c43f1300fe88c05d83db6f3d8f76677ad88",
+                "url": "https://api.github.com/repos/laravel/tinker/zipball/04ad32c1a3328081097a181875733fa51f402083",
+                "reference": "04ad32c1a3328081097a181875733fa51f402083",
                 "shasum": ""
             },
             "require": {
@@ -2217,9 +2223,9 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/tinker/issues",
-                "source": "https://github.com/laravel/tinker/tree/v2.6.0"
+                "source": "https://github.com/laravel/tinker/tree/v2.6.1"
             },
-            "time": "2021-01-26T20:35:18+00:00"
+            "time": "2021-03-02T16:53:12+00:00"
         },
         {
             "name": "laravel/ui",
@@ -2762,23 +2768,23 @@
         },
         {
             "name": "maatwebsite/excel",
-            "version": "3.1.26",
+            "version": "3.1.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Maatwebsite/Laravel-Excel.git",
-                "reference": "66f7c9584304ad0b6a267a5d8ffbfa2ff4272e85"
+                "reference": "1e567e6e19a04fd65b5876d5bc92f4015f09fab4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Maatwebsite/Laravel-Excel/zipball/66f7c9584304ad0b6a267a5d8ffbfa2ff4272e85",
-                "reference": "66f7c9584304ad0b6a267a5d8ffbfa2ff4272e85",
+                "url": "https://api.github.com/repos/Maatwebsite/Laravel-Excel/zipball/1e567e6e19a04fd65b5876d5bc92f4015f09fab4",
+                "reference": "1e567e6e19a04fd65b5876d5bc92f4015f09fab4",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "illuminate/support": "5.8.*|^6.0|^7.0|^8.0",
                 "php": "^7.0|^8.0",
-                "phpoffice/phpspreadsheet": "^1.15"
+                "phpoffice/phpspreadsheet": "1.16.*"
             },
             "require-dev": {
                 "orchestra/testbench": "^6.0",
@@ -2824,7 +2830,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Maatwebsite/Laravel-Excel/issues",
-                "source": "https://github.com/Maatwebsite/Laravel-Excel/tree/3.1.26"
+                "source": "https://github.com/Maatwebsite/Laravel-Excel/tree/3.1.29"
             },
             "funding": [
                 {
@@ -2836,7 +2842,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-27T16:17:38+00:00"
+            "time": "2021-03-16T11:56:39+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
@@ -3295,26 +3301,26 @@
         },
         {
             "name": "myclabs/php-enum",
-            "version": "1.7.7",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/php-enum.git",
-                "reference": "d178027d1e679832db9f38248fcc7200647dc2b7"
+                "reference": "46cf3d8498b095bd33727b13fd5707263af99421"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/d178027d1e679832db9f38248fcc7200647dc2b7",
-                "reference": "d178027d1e679832db9f38248fcc7200647dc2b7",
+                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/46cf3d8498b095bd33727b13fd5707263af99421",
+                "reference": "46cf3d8498b095bd33727b13fd5707263af99421",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": ">=7.1"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7",
+                "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "1.*",
-                "vimeo/psalm": "^3.8"
+                "vimeo/psalm": "^4.5.1"
             },
             "type": "library",
             "autoload": {
@@ -3339,7 +3345,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/php-enum/issues",
-                "source": "https://github.com/myclabs/php-enum/tree/1.7.7"
+                "source": "https://github.com/myclabs/php-enum/tree/1.8.0"
             },
             "funding": [
                 {
@@ -3351,20 +3357,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-14T18:14:52+00:00"
+            "time": "2021-02-15T16:11:48+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.45.1",
+            "version": "2.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "528783b188bdb853eb21239b1722831e0f000a8d"
+                "reference": "2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/528783b188bdb853eb21239b1722831e0f000a8d",
-                "reference": "528783b188bdb853eb21239b1722831e0f000a8d",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4",
+                "reference": "2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4",
                 "shasum": ""
             },
             "require": {
@@ -3444,7 +3450,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-11T18:30:17+00:00"
+            "time": "2021-02-24T17:30:44+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -4093,27 +4099,22 @@
         },
         {
             "name": "psr/container",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -4126,7 +4127,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common Container Interface (PHP FIG PSR-11)",
@@ -4140,9 +4141,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/master"
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
             },
-            "time": "2017-02-14T16:28:37+00:00"
+            "time": "2021-03-05T17:36:06+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -4457,16 +4458,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.10.6",
+            "version": "v0.10.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "6f990c19f91729de8b31e639d6e204ea59f19cf3"
+                "reference": "a395af46999a12006213c0c8346c9445eb31640c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/6f990c19f91729de8b31e639d6e204ea59f19cf3",
-                "reference": "6f990c19f91729de8b31e639d6e204ea59f19cf3",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/a395af46999a12006213c0c8346c9445eb31640c",
+                "reference": "a395af46999a12006213c0c8346c9445eb31640c",
                 "shasum": ""
             },
             "require": {
@@ -4527,9 +4528,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.10.6"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.10.7"
             },
-            "time": "2021-01-18T15:53:43+00:00"
+            "time": "2021-03-14T02:14:56+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -4861,20 +4862,20 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v6.2.5",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "698a6a9f54d7eb321274de3ad19863802c879fb7"
+                "reference": "15f7faf8508e04471f666633addacf54c0ab5933"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/698a6a9f54d7eb321274de3ad19863802c879fb7",
-                "reference": "698a6a9f54d7eb321274de3ad19863802c879fb7",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/15f7faf8508e04471f666633addacf54c0ab5933",
+                "reference": "15f7faf8508e04471f666633addacf54c0ab5933",
                 "shasum": ""
             },
             "require": {
-                "egulias/email-validator": "^2.0",
+                "egulias/email-validator": "^2.0|^3.1",
                 "php": ">=7.0.0",
                 "symfony/polyfill-iconv": "^1.0",
                 "symfony/polyfill-intl-idn": "^1.10",
@@ -4920,7 +4921,7 @@
             ],
             "support": {
                 "issues": "https://github.com/swiftmailer/swiftmailer/issues",
-                "source": "https://github.com/swiftmailer/swiftmailer/tree/v6.2.5"
+                "source": "https://github.com/swiftmailer/swiftmailer/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -4932,20 +4933,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-12T09:35:59+00:00"
+            "time": "2021-03-09T12:30:35+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.2.3",
+            "version": "v5.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "89d4b176d12a2946a1ae4e34906a025b7b6b135a"
+                "reference": "938ebbadae1b0a9c9d1ec313f87f9708609f1b79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/89d4b176d12a2946a1ae4e34906a025b7b6b135a",
-                "reference": "89d4b176d12a2946a1ae4e34906a025b7b6b135a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/938ebbadae1b0a9c9d1ec313f87f9708609f1b79",
+                "reference": "938ebbadae1b0a9c9d1ec313f87f9708609f1b79",
                 "shasum": ""
             },
             "require": {
@@ -5013,7 +5014,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.2.3"
+                "source": "https://github.com/symfony/console/tree/v5.2.5"
             },
             "funding": [
                 {
@@ -5029,11 +5030,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-28T22:06:19+00:00"
+            "time": "2021-03-06T13:42:15+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -5078,7 +5079,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v5.2.3"
+                "source": "https://github.com/symfony/css-selector/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -5165,16 +5166,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "48f18b3609e120ea66d59142c23dc53e9562c26d"
+                "reference": "b547d3babcab5c31e01de59ee33e9d9c1421d7d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/48f18b3609e120ea66d59142c23dc53e9562c26d",
-                "reference": "48f18b3609e120ea66d59142c23dc53e9562c26d",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/b547d3babcab5c31e01de59ee33e9d9c1421d7d0",
+                "reference": "b547d3babcab5c31e01de59ee33e9d9c1421d7d0",
                 "shasum": ""
             },
             "require": {
@@ -5214,7 +5215,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v5.2.3"
+                "source": "https://github.com/symfony/error-handler/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -5230,20 +5231,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-28T22:06:19+00:00"
+            "time": "2021-02-11T08:21:20+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "4f9760f8074978ad82e2ce854dff79a71fe45367"
+                "reference": "d08d6ec121a425897951900ab692b612a61d6240"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/4f9760f8074978ad82e2ce854dff79a71fe45367",
-                "reference": "4f9760f8074978ad82e2ce854dff79a71fe45367",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d08d6ec121a425897951900ab692b612a61d6240",
+                "reference": "d08d6ec121a425897951900ab692b612a61d6240",
                 "shasum": ""
             },
             "require": {
@@ -5299,7 +5300,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.2.3"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -5315,7 +5316,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:36:42+00:00"
+            "time": "2021-02-18T17:12:37+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -5398,16 +5399,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "4adc8d172d602008c204c2e16956f99257248e03"
+                "reference": "0d639a0943822626290d169965804f79400e6a04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/4adc8d172d602008c204c2e16956f99257248e03",
-                "reference": "4adc8d172d602008c204c2e16956f99257248e03",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0d639a0943822626290d169965804f79400e6a04",
+                "reference": "0d639a0943822626290d169965804f79400e6a04",
                 "shasum": ""
             },
             "require": {
@@ -5439,7 +5440,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.2.3"
+                "source": "https://github.com/symfony/finder/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -5455,7 +5456,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-28T22:06:19+00:00"
+            "time": "2021-02-15T18:55:04+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -5538,16 +5539,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "20c554c0f03f7cde5ce230ed248470cccbc34c36"
+                "reference": "54499baea7f7418bce7b5ec92770fd0799e8e9bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/20c554c0f03f7cde5ce230ed248470cccbc34c36",
-                "reference": "20c554c0f03f7cde5ce230ed248470cccbc34c36",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/54499baea7f7418bce7b5ec92770fd0799e8e9bf",
+                "reference": "54499baea7f7418bce7b5ec92770fd0799e8e9bf",
                 "shasum": ""
             },
             "require": {
@@ -5591,7 +5592,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v5.2.3"
+                "source": "https://github.com/symfony/http-foundation/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -5607,20 +5608,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-03T04:42:09+00:00"
+            "time": "2021-02-25T17:16:57+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.2.3",
+            "version": "v5.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "89bac04f29e7b0b52f9fa6a4288ca7a8f90a1a05"
+                "reference": "b8c63ef63c2364e174c3b3e0ba0bf83455f97f73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/89bac04f29e7b0b52f9fa6a4288ca7a8f90a1a05",
-                "reference": "89bac04f29e7b0b52f9fa6a4288ca7a8f90a1a05",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/b8c63ef63c2364e174c3b3e0ba0bf83455f97f73",
+                "reference": "b8c63ef63c2364e174c3b3e0ba0bf83455f97f73",
                 "shasum": ""
             },
             "require": {
@@ -5655,7 +5656,7 @@
                 "psr/log-implementation": "1.0"
             },
             "require-dev": {
-                "psr/cache": "~1.0",
+                "psr/cache": "^1.0|^2.0|^3.0",
                 "symfony/browser-kit": "^4.4|^5.0",
                 "symfony/config": "^5.0",
                 "symfony/console": "^4.4|^5.0",
@@ -5703,7 +5704,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.2.3"
+                "source": "https://github.com/symfony/http-kernel/tree/v5.2.5"
             },
             "funding": [
                 {
@@ -5719,20 +5720,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-03T04:51:58+00:00"
+            "time": "2021-03-10T17:07:35+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v5.2.3",
+            "version": "v5.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "7dee6a43493f39b51ff6c5bb2bd576fe40a76c86"
+                "reference": "554ba128f1955038b45db5e1fa7e93bfc683b139"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/7dee6a43493f39b51ff6c5bb2bd576fe40a76c86",
-                "reference": "7dee6a43493f39b51ff6c5bb2bd576fe40a76c86",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/554ba128f1955038b45db5e1fa7e93bfc683b139",
+                "reference": "554ba128f1955038b45db5e1fa7e93bfc683b139",
                 "shasum": ""
             },
             "require": {
@@ -5743,12 +5744,13 @@
                 "symfony/polyfill-php80": "^1.15"
             },
             "conflict": {
+                "egulias/email-validator": "~3.0.0",
                 "phpdocumentor/reflection-docblock": "<3.2.2",
                 "phpdocumentor/type-resolver": "<1.4.0",
                 "symfony/mailer": "<4.4"
             },
             "require-dev": {
-                "egulias/email-validator": "^2.1.10",
+                "egulias/email-validator": "^2.1.10|^3.1",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
                 "symfony/dependency-injection": "^4.4|^5.0",
                 "symfony/property-access": "^4.4|^5.1",
@@ -5785,7 +5787,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v5.2.3"
+                "source": "https://github.com/symfony/mime/tree/v5.2.5"
             },
             "funding": [
                 {
@@ -5801,11 +5803,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-02T06:10:15+00:00"
+            "time": "2021-03-07T16:08:20+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -5864,7 +5866,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -5884,16 +5886,16 @@
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "b34bfb8c4c22650ac080d2662ae3502e5f2f4ae6"
+                "reference": "06fb361659649bcfd6a208a0f1fcaf4e827ad342"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/b34bfb8c4c22650ac080d2662ae3502e5f2f4ae6",
-                "reference": "b34bfb8c4c22650ac080d2662ae3502e5f2f4ae6",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/06fb361659649bcfd6a208a0f1fcaf4e827ad342",
+                "reference": "06fb361659649bcfd6a208a0f1fcaf4e827ad342",
                 "shasum": ""
             },
             "require": {
@@ -5944,7 +5946,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -5960,20 +5962,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "267a9adeb8ecb8071040a740930e077cdfb987af"
+                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/267a9adeb8ecb8071040a740930e077cdfb987af",
-                "reference": "267a9adeb8ecb8071040a740930e077cdfb987af",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/5601e09b69f26c1828b13b6bb87cb07cddba3170",
+                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170",
                 "shasum": ""
             },
             "require": {
@@ -6025,7 +6027,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -6041,20 +6043,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "0eb8293dbbcd6ef6bf81404c9ce7d95bcdf34f44"
+                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/0eb8293dbbcd6ef6bf81404c9ce7d95bcdf34f44",
-                "reference": "0eb8293dbbcd6ef6bf81404c9ce7d95bcdf34f44",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/2d63434d922daf7da8dd863e7907e67ee3031483",
+                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483",
                 "shasum": ""
             },
             "require": {
@@ -6112,7 +6114,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -6128,20 +6130,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "6e971c891537eb617a00bb07a43d182a6915faba"
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/6e971c891537eb617a00bb07a43d182a6915faba",
-                "reference": "6e971c891537eb617a00bb07a43d182a6915faba",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248",
                 "shasum": ""
             },
             "require": {
@@ -6196,7 +6198,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -6212,20 +6214,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T17:09:11+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13"
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
-                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
                 "shasum": ""
             },
             "require": {
@@ -6276,7 +6278,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -6292,11 +6294,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
@@ -6352,7 +6354,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -6372,7 +6374,7 @@
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -6431,7 +6433,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -6451,7 +6453,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -6514,7 +6516,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -6534,7 +6536,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -6576,7 +6578,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.2.3"
+                "source": "https://github.com/symfony/process/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -6596,16 +6598,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "348b5917e56546c6d96adbf21d7f92c9ef563661"
+                "reference": "cafa138128dfd6ab6be1abf6279169957b34f662"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/348b5917e56546c6d96adbf21d7f92c9ef563661",
-                "reference": "348b5917e56546c6d96adbf21d7f92c9ef563661",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/cafa138128dfd6ab6be1abf6279169957b34f662",
+                "reference": "cafa138128dfd6ab6be1abf6279169957b34f662",
                 "shasum": ""
             },
             "require": {
@@ -6666,7 +6668,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v5.2.3"
+                "source": "https://github.com/symfony/routing/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -6682,7 +6684,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:15:41+00:00"
+            "time": "2021-02-22T15:48:39+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6765,16 +6767,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "c95468897f408dd0aca2ff582074423dd0455122"
+                "reference": "4e78d7d47061fa183639927ec40d607973699609"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/c95468897f408dd0aca2ff582074423dd0455122",
-                "reference": "c95468897f408dd0aca2ff582074423dd0455122",
+                "url": "https://api.github.com/repos/symfony/string/zipball/4e78d7d47061fa183639927ec40d607973699609",
+                "reference": "4e78d7d47061fa183639927ec40d607973699609",
                 "shasum": ""
             },
             "require": {
@@ -6828,7 +6830,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.2.3"
+                "source": "https://github.com/symfony/string/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -6844,20 +6846,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-25T15:14:59+00:00"
+            "time": "2021-02-16T10:20:28+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v5.2.3",
+            "version": "v5.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "c021864d4354ee55160ddcfd31dc477a1bc77949"
+                "reference": "0947ab1e3aabd22a6bef393874b2555d2bb976da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/c021864d4354ee55160ddcfd31dc477a1bc77949",
-                "reference": "c021864d4354ee55160ddcfd31dc477a1bc77949",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/0947ab1e3aabd22a6bef393874b2555d2bb976da",
+                "reference": "0947ab1e3aabd22a6bef393874b2555d2bb976da",
                 "shasum": ""
             },
             "require": {
@@ -6874,7 +6876,7 @@
                 "symfony/yaml": "<4.4"
             },
             "provide": {
-                "symfony/translation-implementation": "2.0"
+                "symfony/translation-implementation": "2.3"
             },
             "require-dev": {
                 "psr/log": "~1.0",
@@ -6921,7 +6923,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.2.3"
+                "source": "https://github.com/symfony/translation/tree/v5.2.5"
             },
             "funding": [
                 {
@@ -6937,7 +6939,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:15:41+00:00"
+            "time": "2021-03-06T07:59:01+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -7019,16 +7021,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.2.3",
+            "version": "v5.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "72ca213014a92223a5d18651ce79ef441c12b694"
+                "reference": "002ab5a36702adf0c9a11e6d8836623253e9045e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/72ca213014a92223a5d18651ce79ef441c12b694",
-                "reference": "72ca213014a92223a5d18651ce79ef441c12b694",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/002ab5a36702adf0c9a11e6d8836623253e9045e",
+                "reference": "002ab5a36702adf0c9a11e6d8836623253e9045e",
                 "shasum": ""
             },
             "require": {
@@ -7087,7 +7089,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.2.3"
+                "source": "https://github.com/symfony/var-dumper/tree/v5.2.5"
             },
             "funding": [
                 {
@@ -7103,7 +7105,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:15:41+00:00"
+            "time": "2021-03-06T07:59:01+00:00"
         },
         {
             "name": "thecodingmachine/safe",
@@ -7779,16 +7781,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.11.1",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad"
+                "reference": "b17c5014ef81d212ac539f07a1001832df1b6d3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
-                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/b17c5014ef81d212ac539f07a1001832df1b6d3b",
+                "reference": "b17c5014ef81d212ac539f07a1001832df1b6d3b",
                 "shasum": ""
             },
             "require": {
@@ -7803,11 +7805,6 @@
                 "phpunit/phpunit": "^7.5 || ^9.1.5"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.11.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
@@ -7848,9 +7845,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.11.1"
+                "source": "https://github.com/doctrine/annotations/tree/1.12.1"
             },
-            "time": "2020-10-26T10:28:16+00:00"
+            "time": "2021-02-21T21:00:45+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -7923,16 +7920,16 @@
         },
         {
             "name": "facade/flare-client-php",
-            "version": "1.3.7",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facade/flare-client-php.git",
-                "reference": "fd688d3c06658f2b3b5f7bb19f051ee4ddf02492"
+                "reference": "ef0f5bce23b30b32d98fd9bb49c6fa37b40eb546"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facade/flare-client-php/zipball/fd688d3c06658f2b3b5f7bb19f051ee4ddf02492",
-                "reference": "fd688d3c06658f2b3b5f7bb19f051ee4ddf02492",
+                "url": "https://api.github.com/repos/facade/flare-client-php/zipball/ef0f5bce23b30b32d98fd9bb49c6fa37b40eb546",
+                "reference": "ef0f5bce23b30b32d98fd9bb49c6fa37b40eb546",
                 "shasum": ""
             },
             "require": {
@@ -7976,7 +7973,7 @@
             ],
             "support": {
                 "issues": "https://github.com/facade/flare-client-php/issues",
-                "source": "https://github.com/facade/flare-client-php/tree/1.3.7"
+                "source": "https://github.com/facade/flare-client-php/tree/1.4.0"
             },
             "funding": [
                 {
@@ -7984,20 +7981,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-21T16:02:39+00:00"
+            "time": "2021-02-16T12:42:06+00:00"
         },
         {
             "name": "facade/ignition",
-            "version": "2.5.11",
+            "version": "2.5.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facade/ignition.git",
-                "reference": "e91d67353054bf827c64687fcac5ea44e4dcec54"
+                "reference": "17097f7a83e200d90d1cf9f4d1b35c1001513a47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facade/ignition/zipball/e91d67353054bf827c64687fcac5ea44e4dcec54",
-                "reference": "e91d67353054bf827c64687fcac5ea44e4dcec54",
+                "url": "https://api.github.com/repos/facade/ignition/zipball/17097f7a83e200d90d1cf9f4d1b35c1001513a47",
+                "reference": "17097f7a83e200d90d1cf9f4d1b35c1001513a47",
                 "shasum": ""
             },
             "require": {
@@ -8061,7 +8058,7 @@
                 "issues": "https://github.com/facade/ignition/issues",
                 "source": "https://github.com/facade/ignition"
             },
-            "time": "2021-02-05T12:52:11+00:00"
+            "time": "2021-03-04T08:48:01+00:00"
         },
         {
             "name": "facade/ignition-contracts",
@@ -8118,16 +8115,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.9.2",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "df7933820090489623ce0be5e85c7e693638e536"
+                "reference": "6ecda5217bf048088b891f7403b262906be5a957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/df7933820090489623ce0be5e85c7e693638e536",
-                "reference": "df7933820090489623ce0be5e85c7e693638e536",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/6ecda5217bf048088b891f7403b262906be5a957",
+                "reference": "6ecda5217bf048088b891f7403b262906be5a957",
                 "shasum": ""
             },
             "require": {
@@ -8177,7 +8174,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.9.2"
+                "source": "https://github.com/filp/whoops/tree/2.10.0"
             },
             "funding": [
                 {
@@ -8185,20 +8182,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-01-24T12:00:00+00:00"
+            "time": "2021-03-16T12:00:00+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.18.2",
+            "version": "v2.18.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "18f8c9d184ba777380794a389fabc179896ba913"
+                "reference": "ab99202fccff2a9f97592fbe1b5c76dd06df3513"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/18f8c9d184ba777380794a389fabc179896ba913",
-                "reference": "18f8c9d184ba777380794a389fabc179896ba913",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/ab99202fccff2a9f97592fbe1b5c76dd06df3513",
+                "reference": "ab99202fccff2a9f97592fbe1b5c76dd06df3513",
                 "shasum": ""
             },
             "require": {
@@ -8260,6 +8257,7 @@
                     "tests/Test/IntegrationCaseFactoryInterface.php",
                     "tests/Test/InternalIntegrationCaseFactory.php",
                     "tests/Test/IsIdenticalConstraint.php",
+                    "tests/Test/TokensWithObservedTransformers.php",
                     "tests/TestCase.php"
                 ]
             },
@@ -8280,7 +8278,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.18.2"
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.18.3"
             },
             "funding": [
                 {
@@ -8288,7 +8286,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-01-26T00:22:21+00:00"
+            "time": "2021-03-10T19:39:05+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -8602,16 +8600,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "20cab678faed06fac225193be281ea0fddb43b93"
+                "reference": "d1339f64479af1bee0e82a0413813fe5345a54ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/20cab678faed06fac225193be281ea0fddb43b93",
-                "reference": "20cab678faed06fac225193be281ea0fddb43b93",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/d1339f64479af1bee0e82a0413813fe5345a54ea",
+                "reference": "d1339f64479af1bee0e82a0413813fe5345a54ea",
                 "shasum": ""
             },
             "require": {
@@ -8668,9 +8666,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mockery/mockery/issues",
-                "source": "https://github.com/mockery/mockery/tree/master"
+                "source": "https://github.com/mockery/mockery/tree/1.4.3"
             },
-            "time": "2020-08-11T18:10:13+00:00"
+            "time": "2021-02-24T09:51:49+00:00"
         },
         {
             "name": "moontoast/math",
@@ -8935,16 +8933,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.0.4",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451"
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/e4782611070e50613683d2b9a57730e9a3ba5451",
-                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
                 "shasum": ""
             },
             "require": {
@@ -8980,9 +8978,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.0.4"
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
             },
-            "time": "2020-12-13T23:18:30+00:00"
+            "time": "2021-02-23T14:00:09+00:00"
         },
         {
             "name": "php-cs-fixer/diff",
@@ -9041,16 +9039,16 @@
         },
         {
             "name": "php-webdriver/webdriver",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-webdriver/php-webdriver.git",
-                "reference": "e3633154554605274cc9d59837f55a7427d72003"
+                "reference": "cd9290b95b7651d495bd69253d6e3ef469a7f211"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/e3633154554605274cc9d59837f55a7427d72003",
-                "reference": "e3633154554605274cc9d59837f55a7427d72003",
+                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/cd9290b95b7651d495bd69253d6e3ef469a7f211",
+                "reference": "cd9290b95b7651d495bd69253d6e3ef469a7f211",
                 "shasum": ""
             },
             "require": {
@@ -9066,7 +9064,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.0",
-                "ondram/ci-detector": "^2.1 || ^3.5",
+                "ondram/ci-detector": "^2.1 || ^3.5 || ^4.0",
                 "php-coveralls/php-coveralls": "^2.4",
                 "php-mock/php-mock-phpunit": "^1.1 || ^2.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -9106,9 +9104,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-webdriver/php-webdriver/issues",
-                "source": "https://github.com/php-webdriver/php-webdriver/tree/1.9.0"
+                "source": "https://github.com/php-webdriver/php-webdriver/tree/1.10.0"
             },
-            "time": "2020-11-19T15:21:05+00:00"
+            "time": "2021-02-25T13:38:09+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -9332,16 +9330,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.2",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "245710e971a030f42e08f4912863805570f23d39"
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
-                "reference": "245710e971a030f42e08f4912863805570f23d39",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
                 "shasum": ""
             },
             "require": {
@@ -9393,9 +9391,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
             },
-            "time": "2020-12-19T10:15:11+00:00"
+            "time": "2021-03-17T13:42:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -9696,16 +9694,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.14",
+            "version": "8.5.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c25f79895d27b6ecd5abfa63de1606b786a461a3"
+                "reference": "038d4196d8e8cb405cd5e82cedfe413ad6eef9ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c25f79895d27b6ecd5abfa63de1606b786a461a3",
-                "reference": "c25f79895d27b6ecd5abfa63de1606b786a461a3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/038d4196d8e8cb405cd5e82cedfe413ad6eef9ef",
+                "reference": "038d4196d8e8cb405cd5e82cedfe413ad6eef9ef",
                 "shasum": ""
             },
             "require": {
@@ -9777,7 +9775,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.14"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.15"
             },
             "funding": [
                 {
@@ -9789,7 +9787,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-01-17T07:37:30+00:00"
+            "time": "2021-03-17T07:27:54+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -10522,16 +10520,16 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v4.4.19",
+            "version": "v4.4.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "af4987aa4a5630e9615be9d9c3ed1b0f24ca449c"
+                "reference": "157bbec4fd773bae53c5483c50951a5530a2cc16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/af4987aa4a5630e9615be9d9c3ed1b0f24ca449c",
-                "reference": "af4987aa4a5630e9615be9d9c3ed1b0f24ca449c",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/157bbec4fd773bae53c5483c50951a5530a2cc16",
+                "reference": "157bbec4fd773bae53c5483c50951a5530a2cc16",
                 "shasum": ""
             },
             "require": {
@@ -10571,7 +10569,7 @@
             "description": "Provides tools to ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/debug/tree/v4.4.19"
+                "source": "https://github.com/symfony/debug/tree/v4.4.20"
             },
             "funding": [
                 {
@@ -10587,20 +10585,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T09:09:26+00:00"
+            "time": "2021-01-28T16:54:48+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "262d033b57c73e8b59cd6e68a45c528318b15038"
+                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/262d033b57c73e8b59cd6e68a45c528318b15038",
-                "reference": "262d033b57c73e8b59cd6e68a45c528318b15038",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/710d364200997a5afde34d9fe57bd52f3cc1e108",
+                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108",
                 "shasum": ""
             },
             "require": {
@@ -10633,7 +10631,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.2.3"
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -10649,11 +10647,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:01:46+00:00"
+            "time": "2021-02-12T10:38:38+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
@@ -10702,7 +10700,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v5.2.3"
+                "source": "https://github.com/symfony/options-resolver/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -10790,7 +10788,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -10832,7 +10830,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.2.3"
+                "source": "https://github.com/symfony/stopwatch/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -10902,30 +10900,35 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.9.1",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "php": "^7.2 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -10949,9 +10952,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
             },
-            "time": "2020-07-08T17:02:28+00:00"
+            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "aliases": [],

--- a/database/migrations/2021_01_20_000000_remove_oids.php
+++ b/database/migrations/2021_01_20_000000_remove_oids.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class RemoveOids extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $tables = DB::select(
+            "select schemaname || '.' || tablename as table_name from pg_tables WHERE schemaname <> 'pg_catalog' AND schemaname <> 'information_schema';"
+        );
+
+        foreach ($tables as $table) {
+            DB::unprepared("alter table {$table->table_name} SET WITHOUT oids;");
+        }
+    }
+}

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_codigo_cartorio_inep_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_codigo_cartorio_inep_table.php
@@ -15,8 +15,6 @@ class CreateCadastroCodigoCartorioInepTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE cadastro.codigo_cartorio_inep_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -32,14 +30,14 @@ class CreateCadastroCodigoCartorioInepTable extends Migration
                     cod_municipio integer,
                     ref_sigla_uf character varying(3)
                 );
-                
+
                 ALTER SEQUENCE cadastro.codigo_cartorio_inep_id_seq OWNED BY cadastro.codigo_cartorio_inep.id;
-                
+
                 ALTER TABLE ONLY cadastro.codigo_cartorio_inep
                     ADD CONSTRAINT pk_id PRIMARY KEY (id);
 
                 ALTER TABLE ONLY cadastro.codigo_cartorio_inep ALTER COLUMN id SET DEFAULT nextval(\'cadastro.codigo_cartorio_inep_id_seq\'::regclass);
-                
+
                 SELECT pg_catalog.setval(\'cadastro.codigo_cartorio_inep_id_seq\', 14212, true);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_deficiencia_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_deficiencia_table.php
@@ -15,8 +15,6 @@ class CreateCadastroDeficienciaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE cadastro.deficiencia_cod_deficiencia_seq
                     START WITH 15
                     INCREMENT BY 1

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_documento_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_documento_table.php
@@ -15,8 +15,6 @@ class CreateCadastroDocumentoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE cadastro.documento (
                     idpes numeric(8,0) NOT NULL,
                     rg character varying(25),
@@ -53,7 +51,7 @@ class CreateCadastroDocumentoTable extends Migration
                     CONSTRAINT ck_documento_origem_gravacao CHECK (((origem_gravacao = \'M\'::bpchar) OR (origem_gravacao = \'U\'::bpchar) OR (origem_gravacao = \'C\'::bpchar) OR (origem_gravacao = \'O\'::bpchar))),
                     CONSTRAINT ck_documento_tipo_cert CHECK (((tipo_cert_civil >= (91)::numeric) AND (tipo_cert_civil <= (92)::numeric)))
                 );
-                
+
                 ALTER TABLE ONLY cadastro.documento
                     ADD CONSTRAINT pk_documento PRIMARY KEY (idpes);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_escolaridade_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_escolaridade_table.php
@@ -15,14 +15,12 @@ class CreateCadastroEscolaridadeTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE cadastro.escolaridade (
                     idesco numeric(2,0) NOT NULL,
                     descricao character varying(60) NOT NULL,
                     escolaridade smallint
                 );
-                
+
                 ALTER TABLE ONLY cadastro.escolaridade
                     ADD CONSTRAINT pk_escolaridade PRIMARY KEY (idesco);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_estado_civil_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_estado_civil_table.php
@@ -15,13 +15,11 @@ class CreateCadastroEstadoCivilTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE cadastro.estado_civil (
                     ideciv numeric(1,0) NOT NULL,
                     descricao character varying(15) NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY cadastro.estado_civil
                     ADD CONSTRAINT pk_estado_civil PRIMARY KEY (ideciv);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_fisica_deficiencia_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_fisica_deficiencia_table.php
@@ -15,13 +15,11 @@ class CreateCadastroFisicaDeficienciaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE cadastro.fisica_deficiencia (
                     ref_idpes integer NOT NULL,
                     ref_cod_deficiencia integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY cadastro.fisica_deficiencia
                     ADD CONSTRAINT pk_fisica_deficiencia PRIMARY KEY (ref_idpes, ref_cod_deficiencia);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_fisica_foto_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_fisica_foto_table.php
@@ -15,14 +15,12 @@ class CreateCadastroFisicaFotoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE cadastro.fisica_foto (
                     idpes integer NOT NULL,
                     caminho character varying(255),
 	                updated_at timestamp NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY cadastro.fisica_foto
                     ADD CONSTRAINT fisica_foto_pkey PRIMARY KEY (idpes);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_fisica_raca_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_fisica_raca_table.php
@@ -15,13 +15,11 @@ class CreateCadastroFisicaRacaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE cadastro.fisica_raca (
                     ref_idpes integer NOT NULL,
                     ref_cod_raca integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY cadastro.fisica_raca
                     ADD CONSTRAINT pk_fisica_raca PRIMARY KEY (ref_idpes);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_fisica_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_fisica_table.php
@@ -15,8 +15,6 @@ class CreateCadastroFisicaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE cadastro.fisica (
                     idpes numeric(8,0) NOT NULL,
                     data_nasc date,
@@ -75,7 +73,7 @@ class CreateCadastroFisicaTable extends Migration
                     CONSTRAINT ck_fisica_origem_gravacao CHECK (((origem_gravacao = \'M\'::bpchar) OR (origem_gravacao = \'U\'::bpchar) OR (origem_gravacao = \'C\'::bpchar) OR (origem_gravacao = \'O\'::bpchar))),
                     CONSTRAINT ck_fisica_sexo CHECK (((sexo = \'M\'::bpchar) OR (sexo = \'F\'::bpchar)))
                 );
-                
+
                 ALTER TABLE ONLY cadastro.fisica
                     ADD CONSTRAINT pk_fisica PRIMARY KEY (idpes);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_fone_pessoa_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_fone_pessoa_table.php
@@ -15,8 +15,6 @@ class CreateCadastroFonePessoaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE cadastro.fone_pessoa (
                     idpes numeric(8,0) NOT NULL,
                     tipo numeric(1,0) NOT NULL,
@@ -32,7 +30,7 @@ class CreateCadastroFonePessoaTable extends Migration
                     CONSTRAINT ck_fone_pessoa_origem_gravacao CHECK (((origem_gravacao = \'M\'::bpchar) OR (origem_gravacao = \'U\'::bpchar) OR (origem_gravacao = \'C\'::bpchar) OR (origem_gravacao = \'O\'::bpchar))),
                     CONSTRAINT ck_fone_pessoa_tipo CHECK (((tipo >= (1)::numeric) AND (tipo <= (4)::numeric)))
                 );
-                
+
                 ALTER TABLE ONLY cadastro.fone_pessoa
                     ADD CONSTRAINT pk_fone_pessoa PRIMARY KEY (idpes, tipo);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_juridica_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_juridica_table.php
@@ -15,8 +15,6 @@ class CreateCadastroJuridicaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE cadastro.juridica (
                     idpes numeric(8,0) NOT NULL,
                     cnpj numeric(14,0) NOT NULL,
@@ -32,10 +30,10 @@ class CreateCadastroJuridicaTable extends Migration
                     CONSTRAINT ck_juridica_operacao CHECK (((operacao = \'I\'::bpchar) OR (operacao = \'A\'::bpchar) OR (operacao = \'E\'::bpchar))),
                     CONSTRAINT ck_juridica_origem_gravacao CHECK (((origem_gravacao = \'M\'::bpchar) OR (origem_gravacao = \'U\'::bpchar) OR (origem_gravacao = \'C\'::bpchar) OR (origem_gravacao = \'O\'::bpchar)))
                 );
-                
+
                 ALTER TABLE ONLY cadastro.juridica
                     ADD CONSTRAINT pk_juridica PRIMARY KEY (idpes);
-                    
+
                 CREATE UNIQUE INDEX un_juridica_cnpj ON cadastro.juridica USING btree (cnpj);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_ocupacao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_ocupacao_table.php
@@ -15,13 +15,11 @@ class CreateCadastroOcupacaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE cadastro.ocupacao (
                     idocup numeric(6,0) NOT NULL,
                     descricao character varying(250) NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY cadastro.ocupacao
                     ADD CONSTRAINT pk_ocupacao PRIMARY KEY (idocup);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_orgao_emissor_rg_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_orgao_emissor_rg_table.php
@@ -15,8 +15,6 @@ class CreateCadastroOrgaoEmissorRgTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE cadastro.orgao_emissor_rg_idorg_rg_seq
                     START WITH 30
                     INCREMENT BY 1
@@ -32,7 +30,7 @@ class CreateCadastroOrgaoEmissorRgTable extends Migration
                     codigo_educacenso integer,
                     CONSTRAINT ck_orgao_emissor_rg_situacao CHECK (((situacao = \'A\'::bpchar) OR (situacao = \'I\'::bpchar)))
                 );
-                
+
                 ALTER TABLE ONLY cadastro.orgao_emissor_rg
                     ADD CONSTRAINT pk_orgao_emissor_rg PRIMARY KEY (idorg_rg);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_pessoa_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_pessoa_table.php
@@ -15,8 +15,6 @@ class CreateCadastroPessoaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE cadastro.seq_pessoa
                     START WITH 0
                     INCREMENT BY 1
@@ -42,7 +40,7 @@ class CreateCadastroPessoaTable extends Migration
                     CONSTRAINT ck_pessoa_situacao CHECK (((situacao = \'A\'::bpchar) OR (situacao = \'I\'::bpchar) OR (situacao = \'P\'::bpchar))),
                     CONSTRAINT ck_pessoa_tipo CHECK (((tipo = \'F\'::bpchar) OR (tipo = \'J\'::bpchar)))
                 );
-                
+
                 ALTER TABLE ONLY cadastro.pessoa
                     ADD CONSTRAINT pk_pessoa PRIMARY KEY (idpes);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_raca_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_raca_table.php
@@ -15,8 +15,6 @@ class CreateCadastroRacaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE cadastro.raca_cod_raca_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreateCadastroRacaTable extends Migration
                     ativo boolean DEFAULT false,
                     raca_educacenso smallint
                 );
-                
+
                 ALTER TABLE ONLY cadastro.raca
                     ADD CONSTRAINT raca_pkey PRIMARY KEY (cod_raca);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_cadastro_religiao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_cadastro_religiao_table.php
@@ -15,8 +15,6 @@ class CreateCadastroReligiaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE cadastro.religiao_cod_religiao_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -33,7 +31,7 @@ class CreateCadastroReligiaoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo boolean DEFAULT false
                 );
-                
+
                 ALTER TABLE ONLY cadastro.religiao
                     ADD CONSTRAINT religiao_pkey PRIMARY KEY (cod_religiao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_area_conhecimento_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_area_conhecimento_table.php
@@ -15,8 +15,6 @@ class CreateModulesAreaConhecimentoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE modules.area_conhecimento_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -32,14 +30,14 @@ class CreateModulesAreaConhecimentoTable extends Migration
                     ordenamento_ac integer DEFAULT 99999,
 	                updated_at timestamp NULL DEFAULT now()
                 );
-                
+
                 ALTER SEQUENCE modules.area_conhecimento_id_seq OWNED BY modules.area_conhecimento.id;
-                
+
                 ALTER TABLE ONLY modules.area_conhecimento
                     ADD CONSTRAINT area_conhecimento_pkey PRIMARY KEY (id, instituicao_id);
 
                 ALTER TABLE ONLY modules.area_conhecimento ALTER COLUMN id SET DEFAULT nextval(\'modules.area_conhecimento_id_seq\'::regclass);
-                
+
                 CREATE INDEX area_conhecimento_nome_key ON modules.area_conhecimento USING btree (nome);
 
                 SELECT pg_catalog.setval(\'modules.area_conhecimento_id_seq\', 2, true);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_auditoria_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_auditoria_table.php
@@ -15,8 +15,6 @@ class CreateModulesAuditoriaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE modules.auditoria (
                     usuario character varying(300),
                     operacao smallint,

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_calendario_turma_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_calendario_turma_table.php
@@ -15,8 +15,6 @@ class CreateModulesCalendarioTurmaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE modules.calendario_turma (
                     calendario_ano_letivo_id integer NOT NULL,
                     ano integer NOT NULL,
@@ -24,7 +22,7 @@ class CreateModulesCalendarioTurmaTable extends Migration
                     dia integer NOT NULL,
                     turma_id integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY modules.calendario_turma
                     ADD CONSTRAINT calendario_turma_pk PRIMARY KEY (calendario_ano_letivo_id, ano, mes, dia, turma_id);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_componente_curricular_ano_escolar_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_componente_curricular_ano_escolar_table.php
@@ -15,8 +15,6 @@ class CreateModulesComponenteCurricularAnoEscolarTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE modules.componente_curricular_ano_escolar (
                     componente_curricular_id integer NOT NULL,
                     ano_escolar_id integer NOT NULL,

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_componente_curricular_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_componente_curricular_table.php
@@ -15,8 +15,6 @@ class CreateModulesComponenteCurricularTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE modules.componente_curricular_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,14 +33,14 @@ class CreateModulesComponenteCurricularTable extends Migration
                     ordenamento integer DEFAULT 99999,
 	                updated_at timestamp NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY modules.componente_curricular
                     ADD CONSTRAINT componente_curricular_pkey PRIMARY KEY (id, instituicao_id);
-                    
+
                 ALTER SEQUENCE modules.componente_curricular_id_seq OWNED BY modules.componente_curricular.id;
-                
+
                 ALTER TABLE ONLY modules.componente_curricular ALTER COLUMN id SET DEFAULT nextval(\'modules.componente_curricular_id_seq\'::regclass);
-                
+
                 CREATE INDEX componente_curricular_area_conhecimento_key ON modules.componente_curricular USING btree (area_conhecimento_id);
 
                 CREATE UNIQUE INDEX componente_curricular_id_key ON modules.componente_curricular USING btree (id);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_componente_curricular_turma_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_componente_curricular_turma_table.php
@@ -15,8 +15,6 @@ class CreateModulesComponenteCurricularTurmaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE modules.componente_curricular_turma (
                     componente_curricular_id integer NOT NULL,
                     ano_escolar_id integer NOT NULL,
@@ -28,10 +26,10 @@ class CreateModulesComponenteCurricularTurmaTable extends Migration
                     etapas_utilizadas character varying,
                     updated_at timestamp without time zone DEFAULT now() NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY modules.componente_curricular_turma
                     ADD CONSTRAINT componente_curricular_turma_pkey PRIMARY KEY (componente_curricular_id, turma_id);
-                    
+
                 CREATE INDEX componente_curricular_turma_turma_idx ON modules.componente_curricular_turma USING btree (turma_id);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_config_movimento_geral_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_config_movimento_geral_table.php
@@ -15,8 +15,6 @@ class CreateModulesConfigMovimentoGeralTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE modules.config_movimento_geral_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -31,12 +29,12 @@ class CreateModulesConfigMovimentoGeralTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.config_movimento_geral_id_seq OWNED BY modules.config_movimento_geral.id;
-                
+
                 ALTER TABLE ONLY modules.config_movimento_geral
                     ADD CONSTRAINT cod_config_movimento_geral_pkey PRIMARY KEY (id);
 
                 ALTER TABLE ONLY modules.config_movimento_geral ALTER COLUMN id SET DEFAULT nextval(\'modules.config_movimento_geral_id_seq\'::regclass);
-                
+
                 SELECT pg_catalog.setval(\'modules.config_movimento_geral_id_seq\', 1, false);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_docente_licenciatura_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_docente_licenciatura_table.php
@@ -15,8 +15,6 @@ class CreateModulesDocenteLicenciaturaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE modules.docente_licenciatura_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -37,7 +35,7 @@ class CreateModulesDocenteLicenciaturaTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.docente_licenciatura_id_seq OWNED BY modules.docente_licenciatura.id;
-                
+
                 ALTER TABLE ONLY modules.docente_licenciatura
                     ADD CONSTRAINT docente_licenciatura_curso_unique UNIQUE (servidor_id, curso_id, ies_id);
 
@@ -45,7 +43,7 @@ class CreateModulesDocenteLicenciaturaTable extends Migration
                     ADD CONSTRAINT docente_licenciatura_pk PRIMARY KEY (id);
 
                 ALTER TABLE ONLY modules.docente_licenciatura ALTER COLUMN id SET DEFAULT nextval(\'modules.docente_licenciatura_id_seq\'::regclass);
-                
+
                 CREATE INDEX docente_licenciatura_ies_idx ON modules.docente_licenciatura USING btree (ies_id);
 
                 SELECT pg_catalog.setval(\'modules.docente_licenciatura_id_seq\', 1, false);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_cod_aluno_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_cod_aluno_table.php
@@ -15,8 +15,6 @@ class CreateModulesEducacensoCodAlunoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE modules.educacenso_cod_aluno (
                     cod_aluno integer NOT NULL,
                     cod_aluno_inep bigint NOT NULL,
@@ -25,7 +23,7 @@ class CreateModulesEducacensoCodAlunoTable extends Migration
                     created_at timestamp without time zone NOT NULL,
                     updated_at timestamp without time zone
                 );
-                
+
                 ALTER TABLE ONLY modules.educacenso_cod_aluno
                     ADD CONSTRAINT educacenso_cod_aluno_pk PRIMARY KEY (cod_aluno, cod_aluno_inep);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_cod_docente_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_cod_docente_table.php
@@ -15,8 +15,6 @@ class CreateModulesEducacensoCodDocenteTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE modules.educacenso_cod_docente (
                     cod_servidor integer NOT NULL,
                     cod_docente_inep bigint NOT NULL,
@@ -25,7 +23,7 @@ class CreateModulesEducacensoCodDocenteTable extends Migration
                     created_at timestamp without time zone NOT NULL,
                     updated_at timestamp without time zone
                 );
-                
+
                 ALTER TABLE ONLY modules.educacenso_cod_docente
                     ADD CONSTRAINT educacenso_cod_docente_pk PRIMARY KEY (cod_servidor, cod_docente_inep);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_cod_escola_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_cod_escola_table.php
@@ -15,8 +15,6 @@ class CreateModulesEducacensoCodEscolaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE modules.educacenso_cod_escola (
                     cod_escola integer NOT NULL,
                     cod_escola_inep bigint NOT NULL,
@@ -25,7 +23,7 @@ class CreateModulesEducacensoCodEscolaTable extends Migration
                     created_at timestamp without time zone NOT NULL,
                     updated_at timestamp without time zone
                 );
-                
+
                 ALTER TABLE ONLY modules.educacenso_cod_escola
                     ADD CONSTRAINT educacenso_cod_escola_pk PRIMARY KEY (cod_escola, cod_escola_inep);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_cod_turma_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_cod_turma_table.php
@@ -15,8 +15,6 @@ class CreateModulesEducacensoCodTurmaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE modules.educacenso_cod_turma (
                     cod_turma integer NOT NULL,
                     cod_turma_inep bigint NOT NULL,
@@ -25,7 +23,7 @@ class CreateModulesEducacensoCodTurmaTable extends Migration
                     created_at timestamp without time zone NOT NULL,
                     updated_at timestamp without time zone
                 );
-                
+
                 ALTER TABLE ONLY modules.educacenso_cod_turma
                     ADD CONSTRAINT educacenso_cod_turma_pk PRIMARY KEY (cod_turma, cod_turma_inep);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_curso_superior_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_curso_superior_table.php
@@ -15,8 +15,6 @@ class CreateModulesEducacensoCursoSuperiorTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE modules.educacenso_curso_superior_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -36,12 +34,12 @@ class CreateModulesEducacensoCursoSuperiorTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.educacenso_curso_superior_id_seq OWNED BY modules.educacenso_curso_superior.id;
-                
+
                 ALTER TABLE ONLY modules.educacenso_curso_superior
                     ADD CONSTRAINT educacenso_curso_superior_pk PRIMARY KEY (id);
 
                 ALTER TABLE ONLY modules.educacenso_curso_superior ALTER COLUMN id SET DEFAULT nextval(\'modules.educacenso_curso_superior_id_seq\'::regclass);
-                
+
                 SELECT pg_catalog.setval(\'modules.educacenso_curso_superior_id_seq\', 338, true);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_ies_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_ies_table.php
@@ -15,8 +15,6 @@ class CreateModulesEducacensoIesTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.educacenso_ies_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -37,12 +35,12 @@ class CreateModulesEducacensoIesTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.educacenso_ies_id_seq OWNED BY modules.educacenso_ies.id;
-                
+
                 ALTER TABLE ONLY modules.educacenso_ies
                     ADD CONSTRAINT educacenso_ies_pk PRIMARY KEY (id);
 
                 ALTER TABLE ONLY modules.educacenso_ies ALTER COLUMN id SET DEFAULT nextval(\'modules.educacenso_ies_id_seq\'::regclass);
-                
+
                 CREATE INDEX idx_educacenso_ies_ies_id ON modules.educacenso_ies USING btree (ies_id);
 
                 SELECT pg_catalog.setval(\'modules.educacenso_ies_id_seq\', 6179, true);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_orgao_regional_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_educacenso_orgao_regional_table.php
@@ -15,13 +15,11 @@ class CreateModulesEducacensoOrgaoRegionalTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE TABLE modules.educacenso_orgao_regional (
                     sigla_uf character varying(2) NOT NULL,
                     codigo character varying(5) NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY modules.educacenso_orgao_regional
                     ADD CONSTRAINT pk_educacenso_orgao_regional PRIMARY KEY (sigla_uf, codigo);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_empresa_transporte_escolar_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_empresa_transporte_escolar_table.php
@@ -15,8 +15,6 @@ class CreateModulesEmpresaTransporteEscolarTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE modules.empresa_transporte_escolar_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -30,7 +28,7 @@ class CreateModulesEmpresaTransporteEscolarTable extends Migration
                     ref_resp_idpes integer NOT NULL,
                     observacao character varying(255)
                 );
-                
+
                 ALTER TABLE ONLY modules.empresa_transporte_escolar
                     ADD CONSTRAINT empresa_transporte_escolar_cod_empresa_transporte_escolar_pkey PRIMARY KEY (cod_empresa_transporte_escolar);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_etapas_curso_educacenso_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_etapas_curso_educacenso_table.php
@@ -15,13 +15,11 @@ class CreateModulesEtapasCursoEducacensoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE TABLE modules.etapas_curso_educacenso (
                     etapa_id integer NOT NULL,
                     curso_id integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY modules.etapas_curso_educacenso
                     ADD CONSTRAINT etapas_curso_educacenso_pk PRIMARY KEY (etapa_id, curso_id);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_etapas_educacenso_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_etapas_educacenso_table.php
@@ -15,13 +15,11 @@ class CreateModulesEtapasEducacensoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE TABLE modules.etapas_educacenso (
                     id integer NOT NULL,
                     nome character varying(255)
                 );
-                
+
                 ALTER TABLE ONLY modules.etapas_educacenso
                     ADD CONSTRAINT etapas_educacenso_pk PRIMARY KEY (id);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_falta_aluno_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_falta_aluno_table.php
@@ -15,8 +15,6 @@ class CreateModulesFaltaAlunoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.falta_aluno_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -31,7 +29,7 @@ class CreateModulesFaltaAlunoTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.falta_aluno_id_seq OWNED BY modules.falta_aluno.id;
-                
+
                 ALTER TABLE ONLY modules.falta_aluno
                     ADD CONSTRAINT falta_aluno_pkey PRIMARY KEY (id);
 
@@ -39,7 +37,7 @@ class CreateModulesFaltaAlunoTable extends Migration
                     ADD CONSTRAINT modules_falta_aluno_matricula_id_unique UNIQUE (matricula_id);
 
                 ALTER TABLE ONLY modules.falta_aluno ALTER COLUMN id SET DEFAULT nextval(\'modules.falta_aluno_id_seq\'::regclass);
-                
+
                 CREATE INDEX idx_falta_aluno_matricula_id ON modules.falta_aluno USING btree (matricula_id);
 
                 CREATE INDEX idx_falta_aluno_matricula_id_tipo ON modules.falta_aluno USING btree (matricula_id, tipo_falta);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_falta_componente_curricular_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_falta_componente_curricular_table.php
@@ -15,8 +15,6 @@ class CreateModulesFaltaComponenteCurricularTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.falta_componente_curricular_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -33,12 +31,12 @@ class CreateModulesFaltaComponenteCurricularTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.falta_componente_curricular_id_seq OWNED BY modules.falta_componente_curricular.id;
-                
+
                 ALTER TABLE ONLY modules.falta_componente_curricular
                     ADD CONSTRAINT falta_componente_curricular_pkey PRIMARY KEY (falta_aluno_id, componente_curricular_id, etapa);
 
                 ALTER TABLE ONLY modules.falta_componente_curricular ALTER COLUMN id SET DEFAULT nextval(\'modules.falta_componente_curricular_id_seq\'::regclass);
-                
+
                 CREATE INDEX idx_falta_componente_curricular_id1 ON modules.falta_componente_curricular USING btree (falta_aluno_id, componente_curricular_id, etapa);
 
                 SELECT pg_catalog.setval(\'modules.falta_componente_curricular_id_seq\', 1, true);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_falta_geral_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_falta_geral_table.php
@@ -15,8 +15,6 @@ class CreateModulesFaltaGeralTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.falta_geral_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -32,12 +30,12 @@ class CreateModulesFaltaGeralTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.falta_geral_id_seq OWNED BY modules.falta_geral.id;
-                
+
                 ALTER TABLE ONLY modules.falta_geral
                     ADD CONSTRAINT falta_geral_pkey PRIMARY KEY (falta_aluno_id, etapa);
 
                 ALTER TABLE ONLY modules.falta_geral ALTER COLUMN id SET DEFAULT nextval(\'modules.falta_geral_id_seq\'::regclass);
-                
+
                 CREATE INDEX idx_falta_geral_falta_aluno_id ON modules.falta_geral USING btree (falta_aluno_id);
 
                 SELECT pg_catalog.setval(\'modules.falta_geral_id_seq\', 1, false);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_ficha_medica_aluno_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_ficha_medica_aluno_table.php
@@ -15,8 +15,6 @@ class CreateModulesFichaMedicaAlunoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE modules.ficha_medica_aluno (
                     ref_cod_aluno integer NOT NULL,
                     altura character varying(4),
@@ -65,7 +63,7 @@ class CreateModulesFichaMedicaAlunoTable extends Migration
                     responsavel_parentesco_celular character varying(20),
                     observacao character varying(255)
                 );
-                
+
                 ALTER TABLE ONLY modules.ficha_medica_aluno
                     ADD CONSTRAINT ficha_medica_cod_aluno_pkey PRIMARY KEY (ref_cod_aluno);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_formula_media_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_formula_media_table.php
@@ -15,8 +15,6 @@ class CreateModulesFormulaMediaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.formula_media_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,12 +32,12 @@ class CreateModulesFormulaMediaTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.formula_media_id_seq OWNED BY modules.formula_media.id;
-                
+
                 ALTER TABLE ONLY modules.formula_media
                     ADD CONSTRAINT formula_media_pkey PRIMARY KEY (id, instituicao_id);
 
                 ALTER TABLE ONLY modules.formula_media ALTER COLUMN id SET DEFAULT nextval(\'modules.formula_media_id_seq\'::regclass);
-                
+
                 SELECT pg_catalog.setval(\'modules.formula_media_id_seq\', 2, true);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_itinerario_transporte_escolar_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_itinerario_transporte_escolar_table.php
@@ -15,8 +15,6 @@ class CreateModulesItinerarioTransporteEscolarTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE modules.itinerario_transporte_escolar_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -33,7 +31,7 @@ class CreateModulesItinerarioTransporteEscolarTable extends Migration
                     hora time without time zone,
                     tipo character(1) NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY modules.itinerario_transporte_escolar
                     ADD CONSTRAINT itinerario_transporte_escolar_cod_itinerario_transporte_escolar PRIMARY KEY (cod_itinerario_transporte_escolar);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_lingua_indigena_educacenso_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_lingua_indigena_educacenso_table.php
@@ -15,13 +15,11 @@ class CreateModulesLinguaIndigenaEducacensoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE TABLE modules.lingua_indigena_educacenso (
                     id integer NOT NULL,
                     lingua character varying(255)
                 );
-                
+
                 ALTER TABLE ONLY modules.lingua_indigena_educacenso
                     ADD CONSTRAINT lingua_indigena_educacenso_pk PRIMARY KEY (id);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_media_geral_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_media_geral_table.php
@@ -15,15 +15,13 @@ class CreateModulesMediaGeralTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE modules.media_geral (
                     nota_aluno_id integer NOT NULL,
                     media numeric(8,4) DEFAULT 0,
                     media_arredondada character varying(10) DEFAULT 0,
                     etapa character varying(2) NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY modules.media_geral
                     ADD CONSTRAINT media_geral_pkey PRIMARY KEY (nota_aluno_id, etapa);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_moradia_aluno_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_moradia_aluno_table.php
@@ -15,8 +15,6 @@ class CreateModulesMoradiaAlunoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE TABLE modules.moradia_aluno (
                     ref_cod_aluno integer NOT NULL,
                     moradia character(1),
@@ -49,7 +47,7 @@ class CreateModulesMoradiaAlunoTable extends Migration
                     fossa character(1),
                     lixo character(1)
                 );
-                
+
                 ALTER TABLE ONLY modules.moradia_aluno
                     ADD CONSTRAINT moradia_aluno_pkei PRIMARY KEY (ref_cod_aluno);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_motorista_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_motorista_table.php
@@ -15,8 +15,6 @@ class CreateModulesMotoristaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE modules.motorista_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreateModulesMotoristaTable extends Migration
                     ref_cod_empresa_transporte_escolar integer NOT NULL,
                     observacao character varying(255)
                 );
-                
+
                 ALTER TABLE ONLY modules.motorista
                     ADD CONSTRAINT motorista_pkey PRIMARY KEY (cod_motorista);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_nota_aluno_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_nota_aluno_table.php
@@ -15,8 +15,6 @@ class CreateModulesNotaAlunoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.nota_aluno_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -30,7 +28,7 @@ class CreateModulesNotaAlunoTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.nota_aluno_id_seq OWNED BY modules.nota_aluno.id;
-                
+
                 ALTER TABLE ONLY modules.nota_aluno
                     ADD CONSTRAINT nota_aluno_pkey PRIMARY KEY (id);
 
@@ -38,7 +36,7 @@ class CreateModulesNotaAlunoTable extends Migration
                     ADD CONSTRAINT modules_nota_aluno_matricula_id_unique UNIQUE (matricula_id);
 
                 ALTER TABLE ONLY modules.nota_aluno ALTER COLUMN id SET DEFAULT nextval(\'modules.nota_aluno_id_seq\'::regclass);
-                
+
                 CREATE INDEX idx_nota_aluno_matricula ON modules.nota_aluno USING btree (matricula_id);
 
                 CREATE INDEX idx_nota_aluno_matricula_id ON modules.nota_aluno USING btree (id, matricula_id);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_nota_componente_curricular_media_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_nota_componente_curricular_media_table.php
@@ -15,8 +15,6 @@ class CreateModulesNotaComponenteCurricularMediaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE modules.nota_componente_curricular_media (
                     nota_aluno_id integer NOT NULL,
                     componente_curricular_id integer NOT NULL,
@@ -26,7 +24,7 @@ class CreateModulesNotaComponenteCurricularMediaTable extends Migration
                     situacao integer,
 	                bloqueada bool NOT NULL DEFAULT false
                 );
-                
+
                 ALTER TABLE ONLY modules.nota_componente_curricular_media
                     ADD CONSTRAINT nota_componente_curricular_media_pkey PRIMARY KEY (nota_aluno_id, componente_curricular_id);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_nota_componente_curricular_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_nota_componente_curricular_table.php
@@ -15,8 +15,6 @@ class CreateModulesNotaComponenteCurricularTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.nota_componente_curricular_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -37,12 +35,12 @@ class CreateModulesNotaComponenteCurricularTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.nota_componente_curricular_id_seq OWNED BY modules.nota_componente_curricular.id;
-                
+
                 ALTER TABLE ONLY modules.nota_componente_curricular
                     ADD CONSTRAINT nota_componente_curricular_pkey PRIMARY KEY (nota_aluno_id, componente_curricular_id, etapa);
 
                 ALTER TABLE ONLY modules.nota_componente_curricular ALTER COLUMN id SET DEFAULT nextval(\'modules.nota_componente_curricular_id_seq\'::regclass);
-                
+
                 CREATE INDEX idx_nota_componente_curricular_etapa ON modules.nota_componente_curricular USING btree (nota_aluno_id, componente_curricular_id, etapa);
 
                 CREATE INDEX idx_nota_componente_curricular_etp ON modules.nota_componente_curricular USING btree (componente_curricular_id, etapa);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_nota_exame_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_nota_exame_table.php
@@ -15,8 +15,6 @@ class CreateModulesNotaExameTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE TABLE modules.nota_exame (
                     ref_cod_matricula integer NOT NULL,
                     ref_cod_componente_curricular integer NOT NULL,

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_nota_geral_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_nota_geral_table.php
@@ -15,8 +15,6 @@ class CreateModulesNotaGeralTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.nota_geral_id_seq
                     START WITH 958638
                     INCREMENT BY 1
@@ -31,7 +29,7 @@ class CreateModulesNotaGeralTable extends Migration
                     nota_arredondada character varying(10) DEFAULT 0,
                     etapa character varying(2) NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY modules.nota_geral
                     ADD CONSTRAINT nota_geral_pkey PRIMARY KEY (id);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_parecer_aluno_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_parecer_aluno_table.php
@@ -15,8 +15,6 @@ class CreateModulesParecerAlunoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.parecer_aluno_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -31,7 +29,7 @@ class CreateModulesParecerAlunoTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.parecer_aluno_id_seq OWNED BY modules.parecer_aluno.id;
-                
+
                 ALTER TABLE ONLY modules.parecer_aluno
                     ADD CONSTRAINT parecer_aluno_pkey PRIMARY KEY (id);
 
@@ -39,7 +37,7 @@ class CreateModulesParecerAlunoTable extends Migration
                     ADD CONSTRAINT modules_parecer_aluno_matricula_id_unique UNIQUE (matricula_id);
 
                 ALTER TABLE ONLY modules.parecer_aluno ALTER COLUMN id SET DEFAULT nextval(\'modules.parecer_aluno_id_seq\'::regclass);
-                
+
                 CREATE INDEX idx_parecer_aluno_matricula_id ON modules.parecer_aluno USING btree (matricula_id);
 
                 SELECT pg_catalog.setval(\'modules.parecer_aluno_id_seq\', 1, false);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_parecer_componente_curricular_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_parecer_componente_curricular_table.php
@@ -15,8 +15,6 @@ class CreateModulesParecerComponenteCurricularTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.parecer_componente_curricular_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -38,7 +36,7 @@ class CreateModulesParecerComponenteCurricularTable extends Migration
                     ADD CONSTRAINT parecer_componente_curricular_pkey PRIMARY KEY (parecer_aluno_id, componente_curricular_id, etapa);
 
                 ALTER TABLE ONLY modules.parecer_componente_curricular ALTER COLUMN id SET DEFAULT nextval(\'modules.parecer_componente_curricular_id_seq\'::regclass);
-                
+
                 CREATE UNIQUE INDEX alunocomponenteetapa ON modules.parecer_componente_curricular USING btree (parecer_aluno_id, componente_curricular_id, etapa);
 
                 SELECT pg_catalog.setval(\'modules.parecer_componente_curricular_id_seq\', 1, false);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_parecer_geral_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_parecer_geral_table.php
@@ -15,8 +15,6 @@ class CreateModulesParecerGeralTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.parecer_geral_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -37,7 +35,7 @@ class CreateModulesParecerGeralTable extends Migration
                     ADD CONSTRAINT parecer_geral_pkey PRIMARY KEY (parecer_aluno_id, etapa);
 
                 ALTER TABLE ONLY modules.parecer_geral ALTER COLUMN id SET DEFAULT nextval(\'modules.parecer_geral_id_seq\'::regclass);
-                
+
                 CREATE INDEX idx_parecer_geral_parecer_aluno_etp ON modules.parecer_geral USING btree (parecer_aluno_id, etapa);
 
                 SELECT pg_catalog.setval(\'modules.parecer_geral_id_seq\', 1, false);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_pessoa_transporte_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_pessoa_transporte_table.php
@@ -15,8 +15,6 @@ class CreateModulesPessoaTransporteTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE modules.pessoa_transporte_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -33,7 +31,7 @@ class CreateModulesPessoaTransporteTable extends Migration
                     observacao character varying(255),
                     turno character varying(255)
                 );
-                
+
                 ALTER TABLE ONLY modules.pessoa_transporte
                     ADD CONSTRAINT pessoa_transporte_cod_pessoa_transporte_pkey PRIMARY KEY (cod_pessoa_transporte);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_ponto_transporte_escolar_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_ponto_transporte_escolar_table.php
@@ -15,8 +15,6 @@ class CreateModulesPontoTransporteEscolarTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE modules.ponto_transporte_escolar_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreateModulesPontoTransporteEscolarTable extends Migration
                     latitude character varying(20),
                     longitude character varying(20)
                 );
-                
+
                 ALTER TABLE ONLY modules.ponto_transporte_escolar
                     ADD CONSTRAINT ponto_transporte_escolar_cod_ponto_transporte_escolar_pkey PRIMARY KEY (cod_ponto_transporte_escolar);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_professor_turma_disciplina_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_professor_turma_disciplina_table.php
@@ -15,13 +15,11 @@ class CreateModulesProfessorTurmaDisciplinaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE TABLE modules.professor_turma_disciplina (
                     professor_turma_id integer NOT NULL,
                     componente_curricular_id integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY modules.professor_turma_disciplina
                     ADD CONSTRAINT professor_turma_disciplina_pk PRIMARY KEY (professor_turma_id, componente_curricular_id);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_professor_turma_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_professor_turma_table.php
@@ -15,8 +15,6 @@ class CreateModulesProfessorTurmaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.professor_turma_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -36,7 +34,7 @@ class CreateModulesProfessorTurmaTable extends Migration
                     updated_at timestamp without time zone,
                     turno_id integer
                 );
-                
+
                 ALTER TABLE ONLY modules.professor_turma
                     ADD CONSTRAINT professor_turma_id_pk PRIMARY KEY (id);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_regra_avaliacao_recuperacao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_regra_avaliacao_recuperacao_table.php
@@ -15,8 +15,6 @@ class CreateModulesRegraAvaliacaoRecuperacaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.regra_avaliacao_recuperacao_id_seq
                     START WITH 1
                     INCREMENT BY 1

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_regra_avaliacao_serie_ano_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_regra_avaliacao_serie_ano_table.php
@@ -15,8 +15,6 @@ class CreateModulesRegraAvaliacaoSerieAnoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE TABLE modules.regra_avaliacao_serie_ano (
                     serie_id integer NOT NULL,
                     regra_avaliacao_id integer NOT NULL,
@@ -24,7 +22,7 @@ class CreateModulesRegraAvaliacaoSerieAnoTable extends Migration
                     ano_letivo smallint NOT NULL,
 	                updated_at timestamp NOT NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY modules.regra_avaliacao_serie_ano
                     ADD CONSTRAINT regra_avaliacao_serie_ano_pkey PRIMARY KEY (serie_id, ano_letivo);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_regra_avaliacao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_regra_avaliacao_table.php
@@ -15,8 +15,6 @@ class CreateModulesRegraAvaliacaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.regra_avaliacao_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -59,12 +57,12 @@ class CreateModulesRegraAvaliacaoTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.regra_avaliacao_id_seq OWNED BY modules.regra_avaliacao.id;
-                
+
                 ALTER TABLE ONLY modules.regra_avaliacao
                     ADD CONSTRAINT regra_avaliacao_pkey PRIMARY KEY (id, instituicao_id);
 
                 ALTER TABLE ONLY modules.regra_avaliacao ALTER COLUMN id SET DEFAULT nextval(\'modules.regra_avaliacao_id_seq\'::regclass);
-                
+
                 CREATE UNIQUE INDEX regra_avaliacao_id_key ON modules.regra_avaliacao USING btree (id);
 
                 SELECT pg_catalog.setval(\'modules.regra_avaliacao_id_seq\', 2, true);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_rota_transporte_escolar_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_rota_transporte_escolar_table.php
@@ -15,8 +15,6 @@ class CreateModulesRotaTransporteEscolarTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE modules.rota_transporte_escolar_seq
                     START WITH 1
                     INCREMENT BY 1

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_tabela_arredondamento_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_tabela_arredondamento_table.php
@@ -15,8 +15,6 @@ class CreateModulesTabelaArredondamentoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE modules.tabela_arredondamento_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,12 +32,12 @@ class CreateModulesTabelaArredondamentoTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.tabela_arredondamento_id_seq OWNED BY modules.tabela_arredondamento.id;
-                
+
                 ALTER TABLE ONLY modules.tabela_arredondamento
                     ADD CONSTRAINT tabela_arredondamento_pkey PRIMARY KEY (id, instituicao_id);
 
                 ALTER TABLE ONLY modules.tabela_arredondamento ALTER COLUMN id SET DEFAULT nextval(\'modules.tabela_arredondamento_id_seq\'::regclass);
-                
+
                 CREATE UNIQUE INDEX tabela_arredondamento_id_key ON modules.tabela_arredondamento USING btree (id);
 
                 SELECT pg_catalog.setval(\'modules.tabela_arredondamento_id_seq\', 2, true);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_tabela_arredondamento_valor_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_tabela_arredondamento_valor_table.php
@@ -15,8 +15,6 @@ class CreateModulesTabelaArredondamentoValorTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE modules.tabela_arredondamento_valor_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -37,12 +35,12 @@ class CreateModulesTabelaArredondamentoValorTable extends Migration
                 );
 
                 ALTER SEQUENCE modules.tabela_arredondamento_valor_id_seq OWNED BY modules.tabela_arredondamento_valor.id;
-                
+
                 ALTER TABLE ONLY modules.tabela_arredondamento_valor
                     ADD CONSTRAINT tabela_arredondamento_valor_pkey PRIMARY KEY (id);
 
                 ALTER TABLE ONLY modules.tabela_arredondamento_valor ALTER COLUMN id SET DEFAULT nextval(\'modules.tabela_arredondamento_valor_id_seq\'::regclass);
-                
+
                 CREATE INDEX idx_tabela_arredondamento_valor_tabela_id ON modules.tabela_arredondamento_valor USING btree (tabela_arredondamento_id);
 
                 SELECT pg_catalog.setval(\'modules.tabela_arredondamento_valor_id_seq\', 26, true);

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_tipo_veiculo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_tipo_veiculo_table.php
@@ -15,8 +15,6 @@ class CreateModulesTipoVeiculoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE modules.tipo_veiculo_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -28,7 +26,7 @@ class CreateModulesTipoVeiculoTable extends Migration
                     cod_tipo_veiculo integer DEFAULT nextval(\'modules.tipo_veiculo_seq\'::regclass) NOT NULL,
                     descricao character varying(60)
                 );
-                
+
                 ALTER TABLE ONLY modules.tipo_veiculo
                     ADD CONSTRAINT tipo_veiculo_pkey PRIMARY KEY (cod_tipo_veiculo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_transporte_aluno_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_transporte_aluno_table.php
@@ -15,8 +15,6 @@ class CreateModulesTransporteAlunoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE modules.transporte_aluno (
                     aluno_id integer NOT NULL,
                     responsavel integer NOT NULL,
@@ -24,7 +22,7 @@ class CreateModulesTransporteAlunoTable extends Migration
                     created_at timestamp without time zone NOT NULL,
                     updated_at timestamp without time zone
                 );
-                
+
                 ALTER TABLE ONLY modules.transporte_aluno
                     ADD CONSTRAINT transporte_aluno_pk PRIMARY KEY (aluno_id);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_uniforme_aluno_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_uniforme_aluno_table.php
@@ -15,8 +15,6 @@ class CreateModulesUniformeAlunoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE TABLE modules.uniforme_aluno (
                     ref_cod_aluno integer NOT NULL,
                     recebeu_uniforme character(1),
@@ -35,7 +33,7 @@ class CreateModulesUniformeAlunoTable extends Migration
                     quantidade_meia integer,
                     tamanho_meia character(2)
                 );
-                
+
                 ALTER TABLE ONLY modules.uniforme_aluno
                     ADD CONSTRAINT uniforme_aluno_pkey PRIMARY KEY (ref_cod_aluno);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_modules_veiculo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_modules_veiculo_table.php
@@ -15,8 +15,6 @@ class CreateModulesVeiculoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE modules.veiculo_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -44,7 +42,7 @@ class CreateModulesVeiculoTable extends Migration
                     ref_cod_motorista integer,
                     observacao character varying(255)
                 );
-                
+
                 ALTER TABLE ONLY modules.veiculo
                     ADD CONSTRAINT veiculo_pkey PRIMARY KEY (cod_veiculo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_abandono_tipo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_abandono_tipo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarAbandonoTipoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE pmieducar.abandono_tipo_cod_abandono_tipo_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreatePmieducarAbandonoTipoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.abandono_tipo
                     ADD CONSTRAINT pk_cod_abandono_tipo PRIMARY KEY (cod_abandono_tipo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_acervo_assunto_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_acervo_assunto_table.php
@@ -15,13 +15,11 @@ class CreatePmieducarAcervoAcervoAssuntoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.acervo_acervo_assunto (
                     ref_cod_acervo integer NOT NULL,
                     ref_cod_acervo_assunto integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.acervo_acervo_assunto
                     ADD CONSTRAINT acervo_acervo_assunto_pkey PRIMARY KEY (ref_cod_acervo, ref_cod_acervo_assunto);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_acervo_autor_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_acervo_autor_table.php
@@ -15,14 +15,12 @@ class CreatePmieducarAcervoAcervoAutorTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.acervo_acervo_autor (
                     ref_cod_acervo_autor integer NOT NULL,
                     ref_cod_acervo integer NOT NULL,
                     principal smallint DEFAULT (0)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.acervo_acervo_autor
                     ADD CONSTRAINT acervo_acervo_autor_pkey PRIMARY KEY (ref_cod_acervo_autor, ref_cod_acervo);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_assunto_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_assunto_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarAcervoAssuntoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.acervo_assunto_cod_acervo_assunto_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarAcervoAssuntoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_biblioteca integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.acervo_assunto
                     ADD CONSTRAINT acervo_assunto_pkey PRIMARY KEY (cod_acervo_assunto);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_autor_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_autor_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarAcervoAutorTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.acervo_autor_cod_acervo_autor_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarAcervoAutorTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_biblioteca integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.acervo_autor
                     ADD CONSTRAINT acervo_autor_pkey PRIMARY KEY (cod_acervo_autor);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_colecao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_colecao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarAcervoColecaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.acervo_colecao_cod_acervo_colecao_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarAcervoColecaoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_biblioteca integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.acervo_colecao
                     ADD CONSTRAINT acervo_colecao_pkey PRIMARY KEY (cod_acervo_colecao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_editora_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_editora_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarAcervoEditoraTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.acervo_editora_cod_acervo_editora_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -43,7 +41,7 @@ class CreatePmieducarAcervoEditoraTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_biblioteca integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.acervo_editora
                     ADD CONSTRAINT acervo_editora_pkey PRIMARY KEY (cod_acervo_editora);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_idioma_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_idioma_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarAcervoIdiomaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.acervo_idioma_cod_acervo_idioma_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreatePmieducarAcervoIdiomaTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_biblioteca integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.acervo_idioma
                     ADD CONSTRAINT acervo_idioma_pkey PRIMARY KEY (cod_acervo_idioma);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_acervo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarAcervoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.acervo_cod_acervo_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -55,7 +53,7 @@ class CreatePmieducarAcervoTable extends Migration
                     ref_cod_tipo_autor integer,
                     tipo_autor character varying(255)
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.acervo
                     ADD CONSTRAINT acervo_pkey PRIMARY KEY (cod_acervo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_aluno_aluno_beneficio_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_aluno_aluno_beneficio_table.php
@@ -15,13 +15,11 @@ class CreatePmieducarAlunoAlunoBeneficioTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.aluno_aluno_beneficio (
                     aluno_id integer NOT NULL,
                     aluno_beneficio_id integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.aluno_aluno_beneficio
                     ADD CONSTRAINT aluno_aluno_beneficio_pk PRIMARY KEY (aluno_id, aluno_beneficio_id);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_aluno_beneficio_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_aluno_beneficio_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarAlunoBeneficioTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.aluno_beneficio_cod_aluno_beneficio_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreatePmieducarAlunoBeneficioTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.aluno_beneficio
                     ADD CONSTRAINT aluno_beneficio_pkey PRIMARY KEY (cod_aluno_beneficio);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_aluno_historico_altura_peso_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_aluno_historico_altura_peso_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarAlunoHistoricoAlturaPesoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.aluno_historico_altura_peso (
                     ref_cod_aluno integer NOT NULL,
                     data_historico date NOT NULL,

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_aluno_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_aluno_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarAlunoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.aluno_cod_aluno_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -59,7 +57,7 @@ class CreatePmieducarAlunoTable extends Migration
 	                updated_at timestamp NULL DEFAULT now(),
 	                emancipado bool NOT NULL DEFAULT false
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.aluno
                     ADD CONSTRAINT aluno_pkey PRIMARY KEY (cod_aluno);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_ano_letivo_modulo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_ano_letivo_modulo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarAnoLetivoModuloTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE TABLE pmieducar.ano_letivo_modulo (
                     ref_ano integer NOT NULL,
                     ref_ref_cod_escola integer NOT NULL,
@@ -26,7 +24,7 @@ class CreatePmieducarAnoLetivoModuloTable extends Migration
                     data_fim date NOT NULL,
                     dias_letivos numeric(5,0)
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.ano_letivo_modulo
                     ADD CONSTRAINT ano_letivo_modulo_pkey PRIMARY KEY (ref_ano, ref_ref_cod_escola, sequencial, ref_cod_modulo);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_avaliacao_desempenho_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_avaliacao_desempenho_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarAvaliacaoDesempenhoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.avaliacao_desempenho (
                     sequencial integer NOT NULL,
                     ref_cod_servidor integer NOT NULL,
@@ -29,7 +27,7 @@ class CreatePmieducarAvaliacaoDesempenhoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     titulo_avaliacao character varying(255) NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.avaliacao_desempenho
                     ADD CONSTRAINT avaliacao_desempenho_pkey PRIMARY KEY (sequencial, ref_cod_servidor, ref_ref_cod_instituicao);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_backup_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_backup_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarBackupTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE pmieducar.backup_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -31,9 +29,9 @@ class CreatePmieducarBackupTable extends Migration
                 );
 
                 ALTER SEQUENCE pmieducar.backup_id_seq OWNED BY pmieducar.backup.id;
-                
+
                 ALTER TABLE ONLY pmieducar.backup ALTER COLUMN id SET DEFAULT nextval(\'pmieducar.backup_id_seq\'::regclass);
-                
+
                 ALTER TABLE ONLY pmieducar.backup
                     ADD CONSTRAINT backup_pkey PRIMARY KEY (id);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_biblioteca_dia_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_biblioteca_dia_table.php
@@ -15,13 +15,11 @@ class CreatePmieducarBibliotecaDiaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.biblioteca_dia (
                     ref_cod_biblioteca integer NOT NULL,
                     dia numeric(1,0) NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.biblioteca_dia
                     ADD CONSTRAINT biblioteca_dia_pkey PRIMARY KEY (ref_cod_biblioteca, dia);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_biblioteca_feriados_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_biblioteca_feriados_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarBibliotecaFeriadosTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.biblioteca_feriados_cod_feriado_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreatePmieducarBibliotecaFeriadosTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     data_feriado date NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.biblioteca_feriados
                     ADD CONSTRAINT biblioteca_feriados_pkey PRIMARY KEY (cod_feriado);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_biblioteca_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_biblioteca_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarBibliotecaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.biblioteca_cod_biblioteca_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -40,7 +38,7 @@ class CreatePmieducarBibliotecaTable extends Migration
                     tombo_automatico boolean DEFAULT true,
                     bloqueia_emprestimo_em_atraso boolean
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.biblioteca
                     ADD CONSTRAINT biblioteca_pkey PRIMARY KEY (cod_biblioteca);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_biblioteca_usuario_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_biblioteca_usuario_table.php
@@ -15,16 +15,14 @@ class CreatePmieducarBibliotecaUsuarioTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.biblioteca_usuario (
                     ref_cod_biblioteca integer NOT NULL,
                     ref_cod_usuario integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.biblioteca_usuario
                     ADD CONSTRAINT biblioteca_usuario_pkey PRIMARY KEY (ref_cod_biblioteca, ref_cod_usuario);
-                    
+
                 CREATE INDEX fki_biblioteca_usuario_ref_cod_biblioteca_fk ON pmieducar.biblioteca_usuario USING btree (ref_cod_biblioteca);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_bloqueio_ano_letivo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_bloqueio_ano_letivo_table.php
@@ -15,15 +15,13 @@ class CreatePmieducarBloqueioAnoLetivoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.bloqueio_ano_letivo (
                     ref_cod_instituicao integer NOT NULL,
                     ref_ano integer NOT NULL,
                     data_inicio date NOT NULL,
                     data_fim date NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.bloqueio_ano_letivo
                     ADD CONSTRAINT pmieducar_bloqueio_ano_letivo_pkey PRIMARY KEY (ref_cod_instituicao, ref_ano);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_bloqueio_lancamento_faltas_notas_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_bloqueio_lancamento_faltas_notas_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarBloqueioLancamentoFaltasNotasTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE public.bloqueio_lancamento_faltas_notas_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -32,7 +30,7 @@ class CreatePmieducarBloqueioLancamentoFaltasNotasTable extends Migration
                     data_inicio date NOT NULL,
                     data_fim date NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.bloqueio_lancamento_faltas_notas
                     ADD CONSTRAINT fk_bloqueio_lancamento_faltas_notas PRIMARY KEY (cod_bloqueio);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_calendario_ano_letivo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_calendario_ano_letivo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarCalendarioAnoLetivoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.calendario_ano_letivo_cod_calendario_ano_letivo_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreatePmieducarCalendarioAnoLetivoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.calendario_ano_letivo
                     ADD CONSTRAINT calendario_ano_letivo_pkey PRIMARY KEY (cod_calendario_ano_letivo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_calendario_anotacao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_calendario_anotacao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarCalendarioAnotacaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.calendario_anotacao_cod_calendario_anotacao_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreatePmieducarCalendarioAnotacaoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.calendario_anotacao
                     ADD CONSTRAINT calendario_anotacao_pkey PRIMARY KEY (cod_calendario_anotacao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_calendario_dia_anotacao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_calendario_dia_anotacao_table.php
@@ -15,15 +15,13 @@ class CreatePmieducarCalendarioDiaAnotacaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.calendario_dia_anotacao (
                     ref_dia integer NOT NULL,
                     ref_mes integer NOT NULL,
                     ref_ref_cod_calendario_ano_letivo integer NOT NULL,
                     ref_cod_calendario_anotacao integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.calendario_dia_anotacao
                     ADD CONSTRAINT calendario_dia_anotacao_pkey PRIMARY KEY (ref_dia, ref_mes, ref_ref_cod_calendario_ano_letivo, ref_cod_calendario_anotacao);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_calendario_dia_motivo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_calendario_dia_motivo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarCalendarioDiaMotivoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.calendario_dia_motivo_cod_calendario_dia_motivo_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -37,7 +35,7 @@ class CreatePmieducarCalendarioDiaMotivoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     nm_motivo character varying(255) NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.calendario_dia_motivo
                     ADD CONSTRAINT calendario_dia_motivo_pkey PRIMARY KEY (cod_calendario_dia_motivo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_calendario_dia_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_calendario_dia_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarCalendarioDiaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.calendario_dia (
                     ref_cod_calendario_ano_letivo integer NOT NULL,
                     mes integer NOT NULL,
@@ -29,10 +27,10 @@ class CreatePmieducarCalendarioDiaTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     descricao text
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.calendario_dia
                     ADD CONSTRAINT calendario_dia_pkey PRIMARY KEY (ref_cod_calendario_ano_letivo, mes, dia);
-                    
+
                 CREATE INDEX i_calendario_dia_ativo ON pmieducar.calendario_dia USING btree (ativo);
 
                 CREATE INDEX i_calendario_dia_dia ON pmieducar.calendario_dia USING btree (dia);

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_candidato_reserva_vaga_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_candidato_reserva_vaga_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarCandidatoReservaVagaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE pmieducar.candidato_reserva_vaga_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -45,7 +43,7 @@ class CreatePmieducarCandidatoReservaVagaTable extends Migration
                     hora_solicitacao time without time zone,
 	                historico json NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.candidato_reserva_vaga
                     ADD CONSTRAINT cod_candidato_reserva_vaga_pkey PRIMARY KEY (cod_candidato_reserva_vaga);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_categoria_nivel_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_categoria_nivel_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarCategoriaNivelTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-                
                 CREATE SEQUENCE pmieducar.categoria_nivel_cod_categoria_nivel_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -33,7 +31,7 @@ class CreatePmieducarCategoriaNivelTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo boolean DEFAULT true NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.categoria_nivel
                     ADD CONSTRAINT categoria_nivel_pkey PRIMARY KEY (cod_categoria_nivel);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_categoria_obra_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_categoria_obra_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarCategoriaObraTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE pmieducar.categoria_obra_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -31,12 +29,12 @@ class CreatePmieducarCategoriaObraTable extends Migration
                 );
 
                 ALTER SEQUENCE pmieducar.categoria_obra_id_seq OWNED BY pmieducar.categoria_obra.id;
-                
+
                 ALTER TABLE ONLY pmieducar.categoria_obra
                     ADD CONSTRAINT categoria_obra_pkey PRIMARY KEY (id);
 
                 ALTER TABLE ONLY pmieducar.categoria_obra ALTER COLUMN id SET DEFAULT nextval(\'pmieducar.categoria_obra_id_seq\'::regclass);
-                
+
                 SELECT pg_catalog.setval(\'pmieducar.categoria_obra_id_seq\', 1, false);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_cliente_suspensao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_cliente_suspensao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarClienteSuspensaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.cliente_suspensao (
                     sequencial integer NOT NULL,
                     ref_cod_cliente integer NOT NULL,
@@ -27,7 +25,7 @@ class CreatePmieducarClienteSuspensaoTable extends Migration
                     data_suspensao timestamp without time zone NOT NULL,
                     data_liberacao timestamp without time zone
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.cliente_suspensao
                     ADD CONSTRAINT cliente_suspensao_pkey PRIMARY KEY (sequencial, ref_cod_cliente, ref_cod_motivo_suspensao);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_cliente_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_cliente_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarClienteTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.cliente_cod_cliente_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -36,7 +34,7 @@ class CreatePmieducarClienteTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     observacoes text
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.cliente
                     ADD CONSTRAINT cliente_login_ukey UNIQUE (login);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_cliente_tipo_cliente_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_cliente_tipo_cliente_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarClienteTipoClienteTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.cliente_tipo_cliente (
                     ref_cod_cliente_tipo integer NOT NULL,
                     ref_cod_cliente integer NOT NULL,
@@ -27,7 +25,7 @@ class CreatePmieducarClienteTipoClienteTable extends Migration
                     ativo smallint DEFAULT (1)::smallint,
                     ref_cod_biblioteca integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.cliente_tipo_cliente
                     ADD CONSTRAINT cliente_tipo_cliente_pk PRIMARY KEY (ref_cod_cliente_tipo, ref_cod_cliente);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_cliente_tipo_exemplar_tipo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_cliente_tipo_exemplar_tipo_table.php
@@ -15,14 +15,12 @@ class CreatePmieducarClienteTipoExemplarTipoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.cliente_tipo_exemplar_tipo (
                     ref_cod_cliente_tipo integer NOT NULL,
                     ref_cod_exemplar_tipo integer NOT NULL,
                     dias_emprestimo numeric(3,0)
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.cliente_tipo_exemplar_tipo
                     ADD CONSTRAINT cliente_tipo_exemplar_tipo_pkey PRIMARY KEY (ref_cod_cliente_tipo, ref_cod_exemplar_tipo);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_cliente_tipo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_cliente_tipo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarClienteTipoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE pmieducar.cliente_tipo_cod_cliente_tipo_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarClienteTipoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.cliente_tipo
                     ADD CONSTRAINT cliente_tipo_pkey PRIMARY KEY (cod_cliente_tipo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_configuracoes_gerais_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_configuracoes_gerais_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarConfiguracoesGeraisTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.configuracoes_gerais (
                     ref_cod_instituicao integer NOT NULL,
                     permite_relacionamento_posvendas integer DEFAULT 1 NOT NULL,
@@ -43,8 +41,8 @@ class CreatePmieducarConfiguracoesGeraisTable extends Migration
                     emitir_ato_autorizativo bool NOT NULL DEFAULT false,
                     emitir_ato_criacao_credenciamento bool NOT NULL DEFAULT false
                 );
-                
-                ALTER TABLE pmieducar.configuracoes_gerais 
+
+                ALTER TABLE pmieducar.configuracoes_gerais
                     ADD CONSTRAINT configuracoes_gerais_pkey PRIMARY KEY (ref_cod_instituicao);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_curso_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_curso_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarCursoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.curso_cod_curso_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -48,7 +46,7 @@ class CreatePmieducarCursoTable extends Migration
                     modalidade_curso integer,
 	                updated_at timestamp NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.curso
                     ADD CONSTRAINT curso_pkey PRIMARY KEY (cod_curso);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_disciplina_dependencia_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_disciplina_dependencia_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarDisciplinaDependenciaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.disciplina_dependencia (
                     ref_cod_matricula integer NOT NULL,
                     ref_cod_disciplina integer NOT NULL,
@@ -26,7 +24,7 @@ class CreatePmieducarDisciplinaDependenciaTable extends Migration
                     cod_disciplina_dependencia integer NOT NULL,
 	                updated_at timestamp NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.disciplina_dependencia
                     ADD CONSTRAINT cod_disciplina_dependencia_pkey PRIMARY KEY (cod_disciplina_dependencia);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_disciplina_serie_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_disciplina_serie_table.php
@@ -15,14 +15,12 @@ class CreatePmieducarDisciplinaSerieTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.disciplina_serie (
                     ref_cod_disciplina integer NOT NULL,
                     ref_cod_serie integer NOT NULL,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.disciplina_serie
                     ADD CONSTRAINT disciplina_serie_pkey PRIMARY KEY (ref_cod_disciplina, ref_cod_serie);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_disciplina_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_disciplina_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarDisciplinaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.disciplina_cod_disciplina_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -39,7 +37,7 @@ class CreatePmieducarDisciplinaTable extends Migration
                     nm_disciplina character varying(255) NOT NULL,
                     ref_cod_curso integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.disciplina
                     ADD CONSTRAINT disciplina_pkey PRIMARY KEY (cod_disciplina);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_disciplina_topico_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_disciplina_topico_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarDisciplinaTopicoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE pmieducar.disciplina_topico_cod_disciplina_topico_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreatePmieducarDisciplinaTopicoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.disciplina_topico
                     ADD CONSTRAINT disciplina_topico_pkey PRIMARY KEY (cod_disciplina_topico);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_dispensa_disciplina_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_dispensa_disciplina_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarDispensaDisciplinaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE pmieducar.dispensa_disciplina_cod_dispensa_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -39,10 +37,10 @@ class CreatePmieducarDispensaDisciplinaTable extends Migration
                     cod_dispensa integer DEFAULT nextval(\'pmieducar.dispensa_disciplina_cod_dispensa_seq\'::regclass) NOT NULL,
 	                updated_at timestamp NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.dispensa_disciplina
                     ADD CONSTRAINT cod_dispensa_pkey PRIMARY KEY (cod_dispensa);
-                    
+
                 CREATE INDEX i_dispensa_disciplina_ref_cod_matricula ON pmieducar.dispensa_disciplina USING btree (ref_cod_matricula);
 
                 SELECT pg_catalog.setval(\'pmieducar.dispensa_disciplina_cod_dispensa_seq\', 1, true);

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_dispensa_etapa_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_dispensa_etapa_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarDispensaEtapaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.dispensa_etapa (
                     ref_cod_dispensa integer,
                     etapa integer

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_distribuicao_uniforme_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_distribuicao_uniforme_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarDistribuicaoUniformeTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.distribuicao_uniforme_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -52,7 +50,7 @@ class CreatePmieducarDistribuicaoUniformeTable extends Migration
                     saia_qtd int2 NULL,
                     saia_tm varchar(20) NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.distribuicao_uniforme
                     ADD CONSTRAINT distribuicao_uniforme_cod_distribuicao_uniforme_pkey PRIMARY KEY (cod_distribuicao_uniforme);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_ano_letivo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_ano_letivo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarEscolaAnoLetivoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.escola_ano_letivo (
                     ref_cod_escola integer NOT NULL,
                     ano integer NOT NULL,
@@ -28,7 +26,7 @@ class CreatePmieducarEscolaAnoLetivoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     turmas_por_ano smallint
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.escola_ano_letivo
                     ADD CONSTRAINT escola_ano_letivo_pkey PRIMARY KEY (ref_cod_escola, ano);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_complemento_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_complemento_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarEscolaComplementoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.escola_complemento (
                     ref_cod_escola integer NOT NULL,
                     ref_usuario_exc integer,
@@ -37,10 +35,10 @@ class CreatePmieducarEscolaComplementoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.escola_complemento
                     ADD CONSTRAINT escola_complemento_pkey PRIMARY KEY (ref_cod_escola);
-                    
+
                 CREATE INDEX i_escola_complemento_ativo ON pmieducar.escola_complemento USING btree (ativo);
 
                 CREATE INDEX i_escola_complemento_bairro ON pmieducar.escola_complemento USING btree (bairro);

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_curso_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_curso_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarEscolaCursoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.escola_curso (
                     ref_cod_escola integer NOT NULL,
                     ref_cod_curso integer NOT NULL,
@@ -29,10 +27,10 @@ class CreatePmieducarEscolaCursoTable extends Migration
                     anos_letivos smallint[] DEFAULT \'{}\'::smallint[] NOT NULL,
 	                updated_at timestamp NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.escola_curso
                     ADD CONSTRAINT escola_curso_pkey PRIMARY KEY (ref_cod_escola, ref_cod_curso);
-                    
+
                 CREATE INDEX i_escola_curso_ativo ON pmieducar.escola_curso USING btree (ativo);
 
                 CREATE INDEX i_escola_curso_ref_usuario_cad ON pmieducar.escola_curso USING btree (ref_usuario_cad);

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_localizacao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_localizacao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarEscolaLocalizacaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.escola_localizacao_cod_escola_localizacao_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreatePmieducarEscolaLocalizacaoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_instituicao integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.escola_localizacao
                     ADD CONSTRAINT escola_localizacao_pkey PRIMARY KEY (cod_escola_localizacao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_rede_ensino_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_rede_ensino_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarEscolaRedeEnsinoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.escola_rede_ensino_cod_escola_rede_ensino_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreatePmieducarEscolaRedeEnsinoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_instituicao integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.escola_rede_ensino
                     ADD CONSTRAINT escola_rede_ensino_pkey PRIMARY KEY (cod_escola_rede_ensino);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_serie_disciplina_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_serie_disciplina_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarEscolaSerieDisciplinaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.escola_serie_disciplina (
 	                id serial NOT NULL,
                     ref_ref_cod_serie integer NOT NULL,
@@ -29,10 +27,10 @@ class CreatePmieducarEscolaSerieDisciplinaTable extends Migration
                     updated_at timestamp without time zone DEFAULT now() NOT NULL,
                     anos_letivos smallint[] DEFAULT \'{}\'::smallint[] NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.escola_serie_disciplina
                     ADD CONSTRAINT escola_serie_disciplina_pkey PRIMARY KEY (id);
-                    
+
                 CREATE UNIQUE INDEX pmieducar_escola_serie_disciplina_ref_ref_cod_serie_ref_ref_cod ON pmieducar.escola_serie_disciplina USING btree (ref_ref_cod_serie, ref_ref_cod_escola, ref_cod_disciplina);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_serie_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_serie_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarEscolaSerieTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE TABLE pmieducar.escola_serie (
                     ref_cod_escola integer NOT NULL,
                     ref_cod_serie integer NOT NULL,
@@ -34,10 +32,10 @@ class CreatePmieducarEscolaSerieTable extends Migration
                     anos_letivos smallint[] DEFAULT \'{}\'::smallint[] NOT NULL,
 	                updated_at timestamp NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.escola_serie
                     ADD CONSTRAINT escola_serie_pkey PRIMARY KEY (ref_cod_escola, ref_cod_serie);
-                    
+
                 CREATE INDEX i_escola_serie_ensino_ativo ON pmieducar.escola_serie USING btree (ativo);
 
                 CREATE INDEX i_escola_serie_hora_final ON pmieducar.escola_serie USING btree (hora_final);

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarEscolaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.escola_cod_escola_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -196,7 +194,7 @@ class CreatePmieducarEscolaTable extends Migration
 	                updated_at timestamp NULL DEFAULT now(),
 	                iddis int4 NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.escola
                     ADD CONSTRAINT escola_pkey PRIMARY KEY (cod_escola);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_usuario_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_escola_usuario_table.php
@@ -17,8 +17,6 @@ class CreatePmieducarEscolaUsuarioTable extends Migration
 
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE pmieducar.escola_usuario_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,9 +32,9 @@ class CreatePmieducarEscolaUsuarioTable extends Migration
                 );
 
                 ALTER SEQUENCE pmieducar.escola_usuario_id_seq OWNED BY pmieducar.escola_usuario.id;
-                
+
                 ALTER TABLE ONLY pmieducar.escola_usuario ALTER COLUMN id SET DEFAULT nextval(\'pmieducar.escola_usuario_id_seq\'::regclass);
-                
+
                 ALTER TABLE ONLY pmieducar.escola_usuario
                     ADD CONSTRAINT escola_usuario_pkey PRIMARY KEY (id);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_exemplar_emprestimo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_exemplar_emprestimo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarExemplarEmprestimoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.exemplar_emprestimo_cod_emprestimo_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreatePmieducarExemplarEmprestimoTable extends Migration
                     data_devolucao timestamp without time zone,
                     valor_multa double precision
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.exemplar_emprestimo
                     ADD CONSTRAINT exemplar_emprestimo_pkey PRIMARY KEY (cod_emprestimo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_exemplar_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_exemplar_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarExemplarTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.exemplar_cod_exemplar_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -42,7 +40,7 @@ class CreatePmieducarExemplarTable extends Migration
                     sequencial integer,
                     data_baixa_exemplar date
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.exemplar
                     ADD CONSTRAINT exemplar_pkey PRIMARY KEY (cod_exemplar);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_exemplar_tipo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_exemplar_tipo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarExemplarTipoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE pmieducar.exemplar_tipo_cod_exemplar_tipo_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarExemplarTipoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.exemplar_tipo
                     ADD CONSTRAINT exemplar_tipo_pkey PRIMARY KEY (cod_exemplar_tipo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_falta_aluno_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_falta_aluno_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarFaltaAlunoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE pmieducar.falta_aluno_cod_falta_aluno_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -39,7 +37,7 @@ class CreatePmieducarFaltaAlunoTable extends Migration
                     modulo smallint NOT NULL,
                     ref_cod_curso_disciplina integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.falta_aluno
                     ADD CONSTRAINT falta_aluno_pkey PRIMARY KEY (cod_falta_aluno);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_falta_atraso_compensado_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_falta_atraso_compensado_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarFaltaAtrasoCompensadoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.falta_atraso_compensado_cod_compensado_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -37,7 +35,7 @@ class CreatePmieducarFaltaAtrasoCompensadoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.falta_atraso_compensado
                     ADD CONSTRAINT falta_atraso_compensado_pkey PRIMARY KEY (cod_compensado);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_falta_atraso_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_falta_atraso_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarFaltaAtrasoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.falta_atraso_cod_falta_atraso_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -40,7 +38,7 @@ class CreatePmieducarFaltaAtrasoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.falta_atraso
                     ADD CONSTRAINT falta_atraso_pkey PRIMARY KEY (cod_falta_atraso);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_faltas_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_faltas_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarFaltasTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE pmieducar.faltas_sequencial_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -31,7 +29,7 @@ class CreatePmieducarFaltasTable extends Migration
                     falta integer NOT NULL,
                     data_cadastro timestamp without time zone NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.faltas
                     ADD CONSTRAINT faltas_pkey PRIMARY KEY (ref_cod_matricula, sequencial);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_fonte_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_fonte_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarFonteTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.fonte_cod_fonte_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarFonteTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_biblioteca integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.fonte
                     ADD CONSTRAINT fonte_pkey PRIMARY KEY (cod_fonte);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_funcao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_funcao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarFuncaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.funcao_cod_funcao_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -36,7 +34,7 @@ class CreatePmieducarFuncaoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_instituicao integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.funcao
                     ADD CONSTRAINT funcao_pkey PRIMARY KEY (cod_funcao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_habilitacao_curso_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_habilitacao_curso_table.php
@@ -15,13 +15,11 @@ class CreatePmieducarHabilitacaoCursoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.habilitacao_curso (
                     ref_cod_habilitacao integer NOT NULL,
                     ref_cod_curso integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.habilitacao_curso
                     ADD CONSTRAINT habilitacao_curso_pkey PRIMARY KEY (ref_cod_habilitacao, ref_cod_curso);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_habilitacao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_habilitacao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarHabilitacaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.habilitacao_cod_habilitacao_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarHabilitacaoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_instituicao integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.habilitacao
                     ADD CONSTRAINT habilitacao_pkey PRIMARY KEY (cod_habilitacao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_historico_disciplinas_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_historico_disciplinas_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarHistoricoDisciplinasTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE TABLE pmieducar.historico_disciplinas (
 	                id serial NOT NULL,
                     sequencial integer NOT NULL,
@@ -31,14 +29,14 @@ class CreatePmieducarHistoricoDisciplinasTable extends Migration
                     dependencia boolean DEFAULT false,
                     tipo_base int4 NOT NULL DEFAULT 1
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.historico_disciplinas
                     ADD CONSTRAINT historico_disciplinas_pkey PRIMARY KEY (id);
 
                 CREATE INDEX idx_historico_disciplinas_id ON pmieducar.historico_disciplinas USING btree (sequencial, ref_ref_cod_aluno, ref_sequencial);
-                
+
                 CREATE INDEX idx_historico_disciplinas_id1 ON pmieducar.historico_disciplinas USING btree (ref_ref_cod_aluno, ref_sequencial);
-                
+
                 CREATE UNIQUE INDEX pmieducar_historico_disciplinas_sequencial_ref_ref_cod_aluno_re ON pmieducar.historico_disciplinas USING btree (sequencial, ref_ref_cod_aluno, ref_sequencial);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_historico_escolar_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_historico_escolar_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarHistoricoEscolarTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.historico_escolar (
 	                id serial NOT NULL,
                     ref_cod_aluno integer NOT NULL,
@@ -52,16 +50,16 @@ class CreatePmieducarHistoricoEscolarTable extends Migration
                     dependencia boolean,
                     posicao integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.historico_escolar
 	                ADD CONSTRAINT historico_escolar_pkey PRIMARY KEY (id);
-                    
+
                 CREATE INDEX historico_escolar_ano_idx ON pmieducar.historico_escolar USING btree (ano);
 
                 CREATE INDEX historico_escolar_ativo_idx ON pmieducar.historico_escolar USING btree (ativo);
 
                 CREATE INDEX historico_escolar_nm_serie_idx ON pmieducar.historico_escolar USING btree (nm_serie);
-                
+
                 CREATE INDEX idx_historico_escolar_aluno_ativo ON pmieducar.historico_escolar USING btree (ref_cod_aluno, ativo);
 
                 CREATE INDEX idx_historico_escolar_id1 ON pmieducar.historico_escolar USING btree (ref_cod_aluno, sequencial);
@@ -69,7 +67,7 @@ class CreatePmieducarHistoricoEscolarTable extends Migration
                 CREATE INDEX idx_historico_escolar_id2 ON pmieducar.historico_escolar USING btree (ref_cod_aluno, sequencial, ano);
 
                 CREATE INDEX idx_historico_escolar_id3 ON pmieducar.historico_escolar USING btree (ref_cod_aluno, ano);
-                
+
                 CREATE UNIQUE INDEX pmieducar_historico_escolar_ref_cod_aluno_sequencial_unique ON pmieducar.historico_escolar USING btree (ref_cod_aluno, sequencial);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_historico_grade_curso_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_historico_grade_curso_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarHistoricoGradeCursoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.historico_grade_curso_seq
                     START WITH 3
                     INCREMENT BY 1
@@ -32,7 +30,7 @@ class CreatePmieducarHistoricoGradeCursoTable extends Migration
                     quantidade_etapas integer,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.historico_grade_curso
                     ADD CONSTRAINT historico_grade_curso_pk PRIMARY KEY (id);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_infra_comodo_funcao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_infra_comodo_funcao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarInfraComodoFuncaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.infra_comodo_funcao_cod_infra_comodo_funcao_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarInfraComodoFuncaoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_escola integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.infra_comodo_funcao
                     ADD CONSTRAINT infra_comodo_funcao_pkey PRIMARY KEY (cod_infra_comodo_funcao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_infra_predio_comodo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_infra_predio_comodo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarInfraPredioComodoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.infra_predio_comodo_cod_infra_predio_comodo_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -37,7 +35,7 @@ class CreatePmieducarInfraPredioComodoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.infra_predio_comodo
                     ADD CONSTRAINT infra_predio_comodo_pkey PRIMARY KEY (cod_infra_predio_comodo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_infra_predio_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_infra_predio_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarInfraPredioTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.infra_predio_cod_infra_predio_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -36,7 +34,7 @@ class CreatePmieducarInfraPredioTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.infra_predio
                     ADD CONSTRAINT infra_predio_pkey PRIMARY KEY (cod_infra_predio);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_instituicao_documentacao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_instituicao_documentacao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarInstituicaoDocumentacaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE pmieducar.instituicao_documentacao_seq
                     START WITH 2
                     INCREMENT BY 1
@@ -32,7 +30,7 @@ class CreatePmieducarInstituicaoDocumentacaoTable extends Migration
                     ref_usuario_cad integer DEFAULT 0 NOT NULL,
                     ref_cod_escola integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.instituicao_documentacao
                     ADD CONSTRAINT instituicao_documentacao_pkey PRIMARY KEY (id);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_instituicao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_instituicao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarInstituicaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.instituicao_cod_instituicao_seq
                     START WITH 0
                     INCREMENT BY 1

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_material_didatico_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_material_didatico_table.php
@@ -15,15 +15,13 @@ class CreatePmieducarMaterialDidaticoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.material_didatico_cod_material_didatico_seq
                     START WITH 1
                     INCREMENT BY 1
                     MINVALUE 0
                     NO MAXVALUE
                     CACHE 1;
-                    
+
                 CREATE TABLE pmieducar.material_didatico (
                     cod_material_didatico integer DEFAULT nextval(\'pmieducar.material_didatico_cod_material_didatico_seq\'::regclass) NOT NULL,
                     ref_cod_instituicao integer NOT NULL,
@@ -37,7 +35,7 @@ class CreatePmieducarMaterialDidaticoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.material_didatico
                     ADD CONSTRAINT material_didatico_pkey PRIMARY KEY (cod_material_didatico);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_material_tipo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_material_tipo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarMaterialTipoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.material_tipo_cod_material_tipo_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarMaterialTipoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_instituicao integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.material_tipo
                     ADD CONSTRAINT material_tipo_pkey PRIMARY KEY (cod_material_tipo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_matricula_excessao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_matricula_excessao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarMatriculaExcessaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE pmieducar.matricula_excessao_cod_aluno_excessao_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -36,7 +34,7 @@ class CreatePmieducarMatriculaExcessaoTable extends Migration
                     precisa_exame boolean NOT NULL,
                     permite_exame boolean
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.matricula_excessao
                     ADD CONSTRAINT matricula_excessao_pk PRIMARY KEY (cod_aluno_excessao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_matricula_ocorrencia_disciplinar_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_matricula_ocorrencia_disciplinar_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarMatriculaOcorrenciaDisciplinarTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.ocorrencia_disciplinar_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -38,7 +36,7 @@ class CreatePmieducarMatriculaOcorrenciaDisciplinarTable extends Migration
                     cod_ocorrencia_disciplinar integer DEFAULT nextval(\'pmieducar.ocorrencia_disciplinar_seq\'::regclass) NOT NULL,
 	                updated_at timestamp NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.matricula_ocorrencia_disciplinar
                     ADD CONSTRAINT matricula_ocorrencia_disciplinar_pkey PRIMARY KEY (ref_cod_matricula, ref_cod_tipo_ocorrencia_disciplinar, sequencial);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_matricula_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_matricula_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarMatriculaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.matricula_cod_matricula_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -55,7 +53,7 @@ class CreatePmieducarMatriculaTable extends Migration
                     data_saida_escola date,
 	                updated_at timestamp NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.matricula
                     ADD CONSTRAINT matricula_pkey PRIMARY KEY (cod_matricula);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_matricula_turma_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_matricula_turma_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarMatriculaTurmaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.matricula_turma (
                     ref_cod_matricula integer NOT NULL,
                     ref_cod_turma integer NOT NULL,
@@ -40,10 +38,10 @@ class CreatePmieducarMatriculaTurmaTable extends Migration
 	                tipo_atendimento int4[] NULL,
 	                updated_at timestamp(0) NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.matricula_turma
                     ADD CONSTRAINT matricula_turma_pkey PRIMARY KEY (id);
-                    
+
                 CREATE INDEX i_matricula_turma_ref_cod_turma ON pmieducar.matricula_turma USING btree (ref_cod_turma);
                 CREATE UNIQUE INDEX matricula_turma_uindex_matricula_turma_sequencial ON pmieducar.matricula_turma USING btree (ref_cod_matricula, ref_cod_turma, sequencial);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_menu_tipo_usuario_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_menu_tipo_usuario_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarMenuTipoUsuarioTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.menu_tipo_usuario (
                     ref_cod_tipo_usuario integer NOT NULL,
 	                menu_id int4 NOT NULL,
@@ -24,7 +22,7 @@ class CreatePmieducarMenuTipoUsuarioTable extends Migration
                     visualiza smallint DEFAULT 0 NOT NULL,
                     exclui smallint DEFAULT 0 NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.menu_tipo_usuario
                     ADD CONSTRAINT menu_tipo_usuario_pkey PRIMARY KEY (ref_cod_tipo_usuario, menu_id);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_modulo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_modulo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarModuloTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.modulo_cod_modulo_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -38,7 +36,7 @@ class CreatePmieducarModuloTable extends Migration
                     ref_cod_instituicao integer NOT NULL,
                     num_etapas numeric(2,0) DEFAULT 0 NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.modulo
                     ADD CONSTRAINT modulo_pkey PRIMARY KEY (cod_modulo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_motivo_afastamento_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_motivo_afastamento_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarMotivoAfastamentoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.motivo_afastamento_cod_motivo_afastamento_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarMotivoAfastamentoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_instituicao integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.motivo_afastamento
                     ADD CONSTRAINT motivo_afastamento_pkey PRIMARY KEY (cod_motivo_afastamento);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_motivo_baixa_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_motivo_baixa_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarMotivoBaixaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.motivo_baixa_cod_motivo_baixa_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarMotivoBaixaTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_biblioteca integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.motivo_baixa
                     ADD CONSTRAINT motivo_baixa_pkey PRIMARY KEY (cod_motivo_baixa);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_motivo_suspensao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_motivo_suspensao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarMotivoSuspensaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.motivo_suspensao_cod_motivo_suspensao_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarMotivoSuspensaoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_biblioteca integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.motivo_suspensao
                     ADD CONSTRAINT motivo_suspensao_pkey PRIMARY KEY (cod_motivo_suspensao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_nivel_ensino_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_nivel_ensino_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarNivelEnsinoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.nivel_ensino_cod_nivel_ensino_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarNivelEnsinoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_instituicao integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.nivel_ensino
                     ADD CONSTRAINT nivel_ensino_pkey PRIMARY KEY (cod_nivel_ensino);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_nivel_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_nivel_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarNivelTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE pmieducar.nivel_cod_nivel_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -36,7 +34,7 @@ class CreatePmieducarNivelTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo boolean DEFAULT true NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.nivel
                     ADD CONSTRAINT nivel_pkey PRIMARY KEY (cod_nivel);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_nota_aluno_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_nota_aluno_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarNotaAlunoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE pmieducar.nota_aluno_cod_nota_aluno_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -41,7 +39,7 @@ class CreatePmieducarNotaAlunoTable extends Migration
                     ref_cod_curso_disciplina integer,
                     nota double precision
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.nota_aluno
                     ADD CONSTRAINT nota_aluno_pkey PRIMARY KEY (cod_nota_aluno);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_operador_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_operador_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarOperadorTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.operador_cod_operador_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarOperadorTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.operador
                     ADD CONSTRAINT operador_pkey PRIMARY KEY (cod_operador);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_pagamento_multa_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_pagamento_multa_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarPagamentoMultaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.pagamento_multa_cod_pagamento_multa_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -32,7 +30,7 @@ class CreatePmieducarPagamentoMultaTable extends Migration
                     data_cadastro timestamp without time zone NOT NULL,
                     ref_cod_biblioteca integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.pagamento_multa
                     ADD CONSTRAINT pagamento_multa_pkey PRIMARY KEY (cod_pagamento_multa);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_pre_requisito_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_pre_requisito_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarPreRequisitoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.pre_requisito_cod_pre_requisito_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -36,7 +34,7 @@ class CreatePmieducarPreRequisitoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.pre_requisito
                     ADD CONSTRAINT pre_requisito_pkey PRIMARY KEY (cod_pre_requisito);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_projeto_aluno_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_projeto_aluno_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarProjetoAlunoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.projeto_aluno (
                     ref_cod_projeto integer NOT NULL,
                     ref_cod_aluno integer NOT NULL,
@@ -24,7 +22,7 @@ class CreatePmieducarProjetoAlunoTable extends Migration
                     data_desligamento date,
                     turno integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.projeto_aluno
                     ADD CONSTRAINT pmieducar_projeto_aluno_pk PRIMARY KEY (ref_cod_projeto, ref_cod_aluno);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_projeto_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_projeto_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarProjetoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.projeto_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -29,7 +27,7 @@ class CreatePmieducarProjetoTable extends Migration
                     nome character varying(50),
                     observacao character varying(255)
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.projeto
                     ADD CONSTRAINT pmieducar_projeto_cod_projeto PRIMARY KEY (cod_projeto);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_quadro_horario_horarios_aux_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_quadro_horario_horarios_aux_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarQuadroHorarioHorariosAuxTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.quadro_horario_horarios_aux (
                     ref_cod_quadro_horario integer NOT NULL,
                     sequencial integer NOT NULL,
@@ -31,7 +29,7 @@ class CreatePmieducarQuadroHorarioHorariosAuxTable extends Migration
                     identificador character varying(30),
                     data_cadastro timestamp without time zone NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.quadro_horario_horarios_aux
                     ADD CONSTRAINT quadro_horario_horarios_aux_pkey PRIMARY KEY (ref_cod_quadro_horario, sequencial);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_quadro_horario_horarios_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_quadro_horario_horarios_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarQuadroHorarioHorariosTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.quadro_horario_horarios (
                     ref_cod_quadro_horario integer NOT NULL,
                     sequencial integer NOT NULL,
@@ -34,10 +32,10 @@ class CreatePmieducarQuadroHorarioHorariosTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.quadro_horario_horarios
                     ADD CONSTRAINT quadro_horario_horarios_pkey PRIMARY KEY (ref_cod_quadro_horario, sequencial);
-                    
+
                 CREATE INDEX quadro_horario_horarios_busca_horarios_idx ON pmieducar.quadro_horario_horarios USING btree (ref_servidor, ref_cod_instituicao_servidor, dia_semana, hora_inicial, hora_final, ativo);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_quadro_horario_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_quadro_horario_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarQuadroHorarioTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.quadro_horario_cod_quadro_horario_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreatePmieducarQuadroHorarioTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ano integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.quadro_horario
                     ADD CONSTRAINT quadro_horario_pkey PRIMARY KEY (cod_quadro_horario);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_quantidade_reserva_externa_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_quantidade_reserva_externa_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarQuantidadeReservaExternaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.quantidade_reserva_externa (
                     ref_cod_instituicao integer NOT NULL,
                     ref_cod_escola integer NOT NULL,
@@ -26,7 +24,7 @@ class CreatePmieducarQuantidadeReservaExternaTable extends Migration
                     ano integer NOT NULL,
                     qtd_alunos integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.quantidade_reserva_externa
                     ADD CONSTRAINT quantidade_reserva_externa_pkey PRIMARY KEY (ref_cod_instituicao, ref_cod_escola, ref_cod_curso, ref_cod_serie, ref_turma_turno_id, ano);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_relacao_categoria_acervo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_relacao_categoria_acervo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarRelacaoCategoriaAcervoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.relacao_categoria_acervo (
                     ref_cod_acervo integer NOT NULL,
                     categoria_id integer NOT NULL

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_religiao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_religiao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarReligiaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.religiao_cod_religiao_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -33,7 +31,7 @@ class CreatePmieducarReligiaoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.religiao
                     ADD CONSTRAINT religiao_pkey PRIMARY KEY (cod_religiao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_reserva_vaga_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_reserva_vaga_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarReservaVagaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.reserva_vaga_cod_reserva_vaga_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -37,7 +35,7 @@ class CreatePmieducarReservaVagaTable extends Migration
                     nm_aluno character varying(255),
                     cpf_responsavel numeric(11,0)
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.reserva_vaga
                     ADD CONSTRAINT reserva_vaga_pkey PRIMARY KEY (cod_reserva_vaga);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_reservas_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_reservas_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarReservasTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.reservas_cod_reserva_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarReservasTable extends Migration
                     ref_cod_exemplar integer NOT NULL,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.reservas
                     ADD CONSTRAINT reservas_pkey PRIMARY KEY (cod_reserva);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_sequencia_serie_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_sequencia_serie_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarSequenciaSerieTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.sequencia_serie (
                     ref_serie_origem integer NOT NULL,
                     ref_serie_destino integer NOT NULL,
@@ -26,7 +24,7 @@ class CreatePmieducarSequenciaSerieTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.sequencia_serie
                     ADD CONSTRAINT sequencia_serie_pkey PRIMARY KEY (ref_serie_origem, ref_serie_destino);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_serie_pre_requisito_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_serie_pre_requisito_table.php
@@ -15,15 +15,13 @@ class CreatePmieducarSeriePreRequisitoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE TABLE pmieducar.serie_pre_requisito (
                     ref_cod_pre_requisito integer NOT NULL,
                     ref_cod_operador integer NOT NULL,
                     ref_cod_serie integer NOT NULL,
                     valor character varying
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.serie_pre_requisito
                     ADD CONSTRAINT serie_pre_requisito_pkey PRIMARY KEY (ref_cod_pre_requisito, ref_cod_operador, ref_cod_serie);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_serie_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_serie_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarSerieTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.serie_cod_serie_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -49,7 +47,7 @@ class CreatePmieducarSerieTable extends Migration
                     exigir_inep boolean,
 	                updated_at timestamp NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.serie
                     ADD CONSTRAINT serie_pkey PRIMARY KEY (cod_serie);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_serie_vaga_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_serie_vaga_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarSerieVagaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.serie_vaga (
                     ano integer NOT NULL,
                     cod_serie_vaga integer NOT NULL,
@@ -27,7 +25,7 @@ class CreatePmieducarSerieVagaTable extends Migration
                     vagas smallint NOT NULL,
                     turno smallint DEFAULT 1 NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.serie_vaga
                     ADD CONSTRAINT cod_serie_vaga_pkey PRIMARY KEY (cod_serie_vaga);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_afastamento_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_afastamento_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarServidorAfastamentoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.servidor_afastamento (
                     ref_cod_servidor integer NOT NULL,
                     sequencial integer NOT NULL,
@@ -30,7 +28,7 @@ class CreatePmieducarServidorAfastamentoTable extends Migration
                     data_saida timestamp without time zone NOT NULL,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.servidor_afastamento
                     ADD CONSTRAINT servidor_afastamento_pkey PRIMARY KEY (ref_cod_servidor, sequencial, ref_ref_cod_instituicao);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_alocacao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_alocacao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarServidorAlocacaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.servidor_alocacao_cod_servidor_alocacao_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -47,7 +45,7 @@ class CreatePmieducarServidorAlocacaoTable extends Migration
                     horas_excedentes time without time zone,
                     data_saida date NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.servidor_alocacao
                     ADD CONSTRAINT servidor_alocacao_pkey PRIMARY KEY (cod_servidor_alocacao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_curso_ministra_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_curso_ministra_table.php
@@ -15,14 +15,12 @@ class CreatePmieducarServidorCursoMinistraTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.servidor_curso_ministra (
                     ref_cod_curso integer NOT NULL,
                     ref_ref_cod_instituicao integer NOT NULL,
                     ref_cod_servidor integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.servidor_curso_ministra
                     ADD CONSTRAINT servidor_cuso_ministra_pkey PRIMARY KEY (ref_cod_curso, ref_ref_cod_instituicao, ref_cod_servidor);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_curso_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_curso_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarServidorCursoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE pmieducar.servidor_curso_cod_servidor_curso_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -31,7 +29,7 @@ class CreatePmieducarServidorCursoTable extends Migration
                     data_registro timestamp without time zone,
                     diplomas_registros text
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.servidor_curso
                     ADD CONSTRAINT servidor_curso_pkey PRIMARY KEY (cod_servidor_curso);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_disciplina_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_disciplina_table.php
@@ -15,15 +15,13 @@ class CreatePmieducarServidorDisciplinaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.servidor_disciplina (
                     ref_cod_disciplina integer NOT NULL,
                     ref_ref_cod_instituicao integer NOT NULL,
                     ref_cod_servidor integer NOT NULL,
                     ref_cod_curso integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.servidor_disciplina
                     ADD CONSTRAINT servidor_disciplina_pkey PRIMARY KEY (ref_cod_disciplina, ref_ref_cod_instituicao, ref_cod_servidor, ref_cod_curso);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_formacao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_formacao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarServidorFormacaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE pmieducar.servidor_formacao_cod_formacao_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -37,7 +35,7 @@ class CreatePmieducarServidorFormacaoTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.servidor_formacao
                     ADD CONSTRAINT servidor_formacao_pkey PRIMARY KEY (cod_formacao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_funcao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_funcao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarServidorFuncaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE pmieducar.servidor_funcao_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -31,7 +29,7 @@ class CreatePmieducarServidorFuncaoTable extends Migration
                     matricula character varying,
                     cod_servidor_funcao integer DEFAULT nextval(\'pmieducar.servidor_funcao_seq\'::regclass) NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.servidor_funcao
                     ADD CONSTRAINT cod_servidor_funcao_pkey PRIMARY KEY (cod_servidor_funcao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarServidorTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.servidor (
                     cod_servidor integer NOT NULL,
                     ref_cod_instituicao integer NOT NULL,
@@ -50,14 +48,14 @@ class CreatePmieducarServidorTable extends Migration
                     tipo_ensino_medio_cursado int4 NULL,
 	                updated_at timestamp NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.servidor
                     ADD CONSTRAINT servidor_pkey PRIMARY KEY (cod_servidor, ref_cod_instituicao);
-                    
+
                 CREATE INDEX fki_servidor_ref_cod_subnivel ON pmieducar.servidor USING btree (ref_cod_subnivel);
 
                 CREATE INDEX fki_servidor_ref_cod_subnivel_ ON pmieducar.servidor USING btree (ref_cod_subnivel);
-                
+
                 CREATE INDEX servidor_idx ON pmieducar.servidor USING btree (cod_servidor, ref_cod_instituicao, ativo);
             '
         );

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_titulo_concurso_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_servidor_titulo_concurso_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarServidorTituloConcursoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.servidor_titulo_concurso_cod_servidor_titulo_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -30,7 +28,7 @@ class CreatePmieducarServidorTituloConcursoTable extends Migration
                     data_vigencia_homolog timestamp without time zone NOT NULL,
                     data_publicacao timestamp without time zone NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.servidor_titulo_concurso
                     ADD CONSTRAINT servidor_titulo_concurso_pkey PRIMARY KEY (cod_servidor_titulo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_situacao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_situacao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarSituacaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE pmieducar.situacao_cod_situacao_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -38,7 +36,7 @@ class CreatePmieducarSituacaoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_biblioteca integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.situacao
                     ADD CONSTRAINT situacao_pkey PRIMARY KEY (cod_situacao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_subnivel_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_subnivel_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarSubnivelTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE SEQUENCE pmieducar.subnivel_cod_subnivel_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -36,7 +34,7 @@ class CreatePmieducarSubnivelTable extends Migration
                     ativo boolean DEFAULT true NOT NULL,
                     salario double precision NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.subnivel
                     ADD CONSTRAINT subnivel_pkey PRIMARY KEY (cod_subnivel);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_autor_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_autor_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTipoAutorTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = false;
-
                 CREATE TABLE pmieducar.tipo_autor (
                     codigo integer,
                     tipo_autor character varying(255)

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_avaliacao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_avaliacao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTipoAvaliacaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE pmieducar.tipo_avaliacao_cod_tipo_avaliacao_seq
                     START WITH 1
                     INCREMENT BY 1

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_avaliacao_valores_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_avaliacao_valores_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTipoAvaliacaoValoresTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.tipo_avaliacao_valores (
                     ref_cod_tipo_avaliacao integer NOT NULL,
                     sequencial integer NOT NULL,
@@ -26,7 +24,7 @@ class CreatePmieducarTipoAvaliacaoValoresTable extends Migration
                     valor_max double precision NOT NULL,
                     ativo boolean DEFAULT true
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.tipo_avaliacao_valores
                     ADD CONSTRAINT tipo_avaliacao_valores_pkey PRIMARY KEY (ref_cod_tipo_avaliacao, sequencial);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_dispensa_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_dispensa_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTipoDispensaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.tipo_dispensa_cod_tipo_dispensa_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarTipoDispensaTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_instituicao integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.tipo_dispensa
                     ADD CONSTRAINT tipo_dispensa_pkey PRIMARY KEY (cod_tipo_dispensa);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_ensino_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_ensino_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTipoEnsinoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.tipo_ensino_cod_tipo_ensino_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarTipoEnsinoTable extends Migration
                     ref_cod_instituicao integer NOT NULL,
                     atividade_complementar boolean DEFAULT false
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.tipo_ensino
                     ADD CONSTRAINT tipo_ensino_pkey PRIMARY KEY (cod_tipo_ensino);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_ocorrencia_disciplinar_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_ocorrencia_disciplinar_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTipoOcorrenciaDisciplinarTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.tipo_ocorrencia_disciplinar_cod_tipo_ocorrencia_disciplinar_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -36,7 +34,7 @@ class CreatePmieducarTipoOcorrenciaDisciplinarTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_instituicao integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.tipo_ocorrencia_disciplinar
                     ADD CONSTRAINT tipo_ocorrencia_disciplinar_pkey PRIMARY KEY (cod_tipo_ocorrencia_disciplinar);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_regime_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_regime_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTipoRegimeTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.tipo_regime_cod_tipo_regime_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -34,7 +32,7 @@ class CreatePmieducarTipoRegimeTable extends Migration
                     ativo smallint NOT NULL,
                     ref_cod_instituicao integer NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.tipo_regime
                     ADD CONSTRAINT tipo_regime_pkey PRIMARY KEY (cod_tipo_regime);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_usuario_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_tipo_usuario_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTipoUsuarioTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.tipo_usuario_cod_tipo_usuario_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarTipoUsuarioTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.tipo_usuario
                     ADD CONSTRAINT tipo_usuario_pkey PRIMARY KEY (cod_tipo_usuario);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_transferencia_solicitacao_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_transferencia_solicitacao_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTransferenciaSolicitacaoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE pmieducar.transferencia_solicitacao_cod_transferencia_solicitacao_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -41,7 +39,7 @@ class CreatePmieducarTransferenciaSolicitacaoTable extends Migration
                     estado_escola_destino_externa character varying(60),
                     municipio_escola_destino_externa character varying(60)
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.transferencia_solicitacao
                     ADD CONSTRAINT transferencia_solicitacao_pkey PRIMARY KEY (cod_transferencia_solicitacao);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_transferencia_tipo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_transferencia_tipo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTransferenciaTipoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.transferencia_tipo_cod_transferencia_tipo_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarTransferenciaTipoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_instituicao integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.transferencia_tipo
                     ADD CONSTRAINT transferencia_tipo_pkey PRIMARY KEY (cod_transferencia_tipo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_turma_modulo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_turma_modulo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTurmaModuloTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE TABLE pmieducar.turma_modulo (
                     ref_cod_turma integer NOT NULL,
                     ref_cod_modulo integer NOT NULL,
@@ -25,7 +23,7 @@ class CreatePmieducarTurmaModuloTable extends Migration
                     data_fim date NOT NULL,
                     dias_letivos integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.turma_modulo
                     ADD CONSTRAINT turma_modulo_pkey PRIMARY KEY (ref_cod_turma, ref_cod_modulo, sequencial);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_turma_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_turma_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTurmaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.turma_cod_turma_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -88,7 +86,7 @@ class CreatePmieducarTurmaTable extends Migration
                     local_funcionamento_diferenciado int2 NULL,
 	                updated_at timestamp NULL DEFAULT now()
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.turma
                     ADD CONSTRAINT turma_pkey PRIMARY KEY (cod_turma);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_turma_tipo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_turma_tipo_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTurmaTipoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.turma_tipo_cod_turma_tipo_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePmieducarTurmaTipoTable extends Migration
                     ativo smallint DEFAULT (1)::smallint NOT NULL,
                     ref_cod_instituicao integer
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.turma_tipo
                     ADD CONSTRAINT turma_tipo_pkey PRIMARY KEY (cod_turma_tipo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_turma_turno_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_turma_turno_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarTurmaTurnoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE pmieducar.turma_turno_id_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -29,7 +27,7 @@ class CreatePmieducarTurmaTurnoTable extends Migration
                     nome character varying(15) NOT NULL,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.turma_turno
                     ADD CONSTRAINT turma_turno_pkey PRIMARY KEY (id);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_pmieducar_usuario_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_pmieducar_usuario_table.php
@@ -15,8 +15,6 @@ class CreatePmieducarUsuarioTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE TABLE pmieducar.usuario (
                     cod_usuario integer NOT NULL,
                     ref_cod_instituicao integer,
@@ -27,7 +25,7 @@ class CreatePmieducarUsuarioTable extends Migration
                     data_exclusao timestamp without time zone,
                     ativo smallint DEFAULT (1)::smallint NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY pmieducar.usuario
                     ADD CONSTRAINT usuario_pkey PRIMARY KEY (cod_usuario);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_portal_acesso_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_portal_acesso_table.php
@@ -15,8 +15,6 @@ class CreatePortalAcessoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE portal.acesso_cod_acesso_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -33,7 +31,7 @@ class CreatePortalAcessoTable extends Migration
                     obs text,
                     sucesso boolean DEFAULT true NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY portal.acesso
                     ADD CONSTRAINT acesso_pk PRIMARY KEY (cod_acesso);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_portal_agenda_compromisso_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_portal_agenda_compromisso_table.php
@@ -15,8 +15,6 @@ class CreatePortalAgendaCompromissoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE TABLE portal.agenda_compromisso (
                     cod_agenda_compromisso integer NOT NULL,
                     versao integer NOT NULL,
@@ -31,7 +29,7 @@ class CreatePortalAgendaCompromissoTable extends Migration
                     data_cadastro timestamp without time zone NOT NULL,
                     data_fim timestamp without time zone
                 );
-                
+
                 ALTER TABLE ONLY portal.agenda_compromisso
                     ADD CONSTRAINT agenda_compromisso_pkey PRIMARY KEY (cod_agenda_compromisso, versao, ref_cod_agenda);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_portal_agenda_responsavel_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_portal_agenda_responsavel_table.php
@@ -15,14 +15,12 @@ class CreatePortalAgendaResponsavelTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE TABLE portal.agenda_responsavel (
                     ref_cod_agenda integer NOT NULL,
                     ref_ref_cod_pessoa_fj integer NOT NULL,
                     principal smallint
                 );
-                
+
                 ALTER TABLE ONLY portal.agenda_responsavel
                     ADD CONSTRAINT agenda_responsavel_pkey PRIMARY KEY (ref_cod_agenda, ref_ref_cod_pessoa_fj);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_portal_agenda_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_portal_agenda_table.php
@@ -15,8 +15,6 @@ class CreatePortalAgendaTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE portal.agenda_cod_agenda_seq
                     START WITH 0
                     INCREMENT BY 1
@@ -35,7 +33,7 @@ class CreatePortalAgendaTable extends Migration
                     data_edicao timestamp without time zone,
                     ref_ref_cod_pessoa_own integer
                 );
-                
+
                 ALTER TABLE ONLY portal.agenda
                     ADD CONSTRAINT agenda_pkey PRIMARY KEY (cod_agenda);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_portal_funcionario_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_portal_funcionario_table.php
@@ -15,8 +15,6 @@ class CreatePortalFuncionarioTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE TABLE portal.funcionario (
                     ref_cod_pessoa_fj integer DEFAULT 0 NOT NULL,
                     matricula character varying(12),
@@ -47,7 +45,7 @@ class CreatePortalFuncionarioTable extends Migration
                     atualizou_cadastro smallint,
 	                data_expiracao date NULL
                 );
-                
+
                 ALTER TABLE ONLY portal.funcionario
                     ADD CONSTRAINT funcionario_pk PRIMARY KEY (ref_cod_pessoa_fj);
             '

--- a/database/migrations/legacy/2020_01_01_110000_create_portal_funcionario_vinculo_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_portal_funcionario_vinculo_table.php
@@ -15,8 +15,6 @@ class CreatePortalFuncionarioVinculoTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-
                 CREATE SEQUENCE portal.funcionario_vinculo_cod_funcionario_vinculo_seq
                     START WITH 1
                     INCREMENT BY 1
@@ -29,7 +27,7 @@ class CreatePortalFuncionarioVinculoTable extends Migration
                     nm_vinculo character varying(255) DEFAULT \'\'::character varying NOT NULL,
                     abreviatura character varying(16)
                 );
-                
+
                 ALTER TABLE ONLY portal.funcionario_vinculo
                     ADD CONSTRAINT funcionario_vinculo_pk PRIMARY KEY (cod_funcionario_vinculo);
 

--- a/database/migrations/legacy/2020_01_01_110000_create_public_setor_bai_table.php
+++ b/database/migrations/legacy/2020_01_01_110000_create_public_setor_bai_table.php
@@ -15,8 +15,6 @@ class CreatePublicSetorBaiTable extends Migration
     {
         DB::unprepared(
             '
-                SET default_with_oids = true;
-                
                 CREATE SEQUENCE public.seq_setor_bai
                     START WITH 1
                     INCREMENT BY 1
@@ -28,7 +26,7 @@ class CreatePublicSetorBaiTable extends Migration
                     idsetorbai numeric(6,0) DEFAULT nextval((\'public.seq_setor_bai\'::text)::regclass) NOT NULL,
                     nome character varying(80) NOT NULL
                 );
-                
+
                 ALTER TABLE ONLY public.setor_bai
                     ADD CONSTRAINT pk_setorbai PRIMARY KEY (idsetorbai);
 


### PR DESCRIPTION
Prepara o banco de dados do i-Educar para o Postgres 13. O uso de OIDS já está removido em versões anteriores, porém como o i-Educar ainda utilizava a versão 9.5 sua remoção nunca foi feita.