### PR TITLE
Restaura o filtro de situação na listagem de alunos

### DIFF
--- a/app/Models/Builders/LegacyStudentBuilder.php
+++ b/app/Models/Builders/LegacyStudentBuilder.php
@@ -3,6 +3,8 @@
 namespace App\Models\Builders;
 
 use App\Models\DataSearch\StudentFilter;
+use App\Models\RegistrationStatus;
+use iEducar\Modules\Enrollments\Model\EnrollmentStatusFilter;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class LegacyStudentBuilder extends LegacyBuilder
@@ -149,17 +151,20 @@ class LegacyStudentBuilder extends LegacyBuilder
         });
     }
 
-    public function whereRegistration($year, $course, $grade, $school)
+    public function whereRegistration($year, $course, $grade, $school, $status = null)
     {
-        return $this->where(function ($query) use ($year, $course, $grade, $school) {
+        return $this->where(function ($query) use ($year, $course, $grade, $school, $status) {
             $query->whereHas(
                 'registrations',
-                function ($query) use ($year, $course, $grade, $school) {
+                function ($query) use ($year, $course, $grade, $school, $status) {
                     $query->active();
                     $query->when($year, fn ($q) => $q->where('ano', $year));
                     $query->when($course, fn ($q) => $q->where('ref_cod_curso', $course));
                     $query->when($school, fn ($q) => $q->where('ref_ref_cod_escola', $school));
                     $query->when($grade, fn ($q) => $q->where('ref_ref_cod_serie', $grade));
+                    $query->when($status, fn ($q) => (int) $status === EnrollmentStatusFilter::EXCEPT_TRANSFERRED_OR_ABANDONMENT
+                        ? $q->whereNotIn('aprovado', [RegistrationStatus::TRANSFERRED, RegistrationStatus::ABANDONED])
+                        : $q->where('aprovado', $status));
                 }
             );
         });
@@ -198,6 +203,7 @@ class LegacyStudentBuilder extends LegacyBuilder
                         'course' => $studentFilter->course,
                         'school' => $studentFilter->school,
                         'year' => $studentFilter->year,
+                        'status' => $studentFilter->enrollmentStatus,
                     ],
                 ]
             )

--- a/app/Models/DataSearch/StudentFilter.php
+++ b/app/Models/DataSearch/StudentFilter.php
@@ -20,6 +20,7 @@ class StudentFilter
         public readonly ?int $school = null,
         public readonly ?int $course = null,
         public readonly ?int $grade = null,
+        public readonly ?int $enrollmentStatus = null,
         public readonly ?int $perPage = null,
         public readonly ?string $pageName = null,
         public readonly ?bool $similarity = null,

--- a/ieducar/intranet/educar_aluno_lst.php
+++ b/ieducar/intranet/educar_aluno_lst.php
@@ -2,6 +2,7 @@
 
 use App\Models\DataSearch\StudentFilter;
 use App\Models\LegacyStudent;
+use iEducar\Modules\Enrollments\Model\EnrollmentStatusFilter;
 
 return new class extends clsListagem
 {
@@ -100,6 +101,7 @@ return new class extends clsListagem
         $this->inputsHelper()->dynamic(helperNames: 'escolaSemFiltroPorUsuario', inputOptions: ['required' => false, 'value' => $this->ref_cod_escola, 'label_hint' => 'Retorna alunos com matrículas na escola selecionada']);
         $this->inputsHelper()->dynamic(helperNames: 'curso', inputOptions: ['required' => false, 'label_hint' => 'Retorna alunos com matrículas no curso selecionado']);
         $this->inputsHelper()->dynamic(helperNames: 'serie', inputOptions: ['required' => false, 'label_hint' => 'Retorna alunos com matrículas na série selecionada']);
+        $this->inputsHelper()->dynamic(helperNames: 'situacaoMatricula', inputOptions: ['required' => false, 'label_hint' => 'Retorna alunos com matrículas compatíveis com esta situação']);
 
         $obj_permissoes = new clsPermissoes;
         $cod_escola = $obj_permissoes->getEscola(int_idpes_usuario: $this->pessoa_logada);
@@ -134,6 +136,7 @@ return new class extends clsListagem
         $dataFilter = [
             'rg' => preg_replace(pattern: '/\D/', replacement: '', subject: $this->rg_aluno),
             'year' => $this->ano,
+            'enrollmentStatus' => ((int) $this->situacao_matricula_id && (int) $this->situacao_matricula_id !== EnrollmentStatusFilter::ALL) ? (int) $this->situacao_matricula_id : null,
             'cpf' => preg_replace(pattern: '/\D/', replacement: '', subject: $this->cpf_aluno),
             'inep' => $this->cod_inep,
             'grade' => $this->ref_cod_serie,


### PR DESCRIPTION
## Contexto

A listagem de alunos (`ieducar/intranet/educar_aluno_lst.php`) tinha um filtro **"Situação"** (situação da matrícula: Cursando, Transferido, Falecido, etc.) que facilitava localizar alunos em situações específicas.

Ele foi removido em 2022: primeiro a busca deixou de usar o `INNER JOIN` com a view `relatorio.view_situacao`, passando a filtrar direto em `matricula.aprovado` (commit `e1aab68bd`, "Remove view situação e aplica filtro direto na matricula"), e em seguida o campo saiu da tela (commit `0c6dd38e1` / merge `862d72c9c`, branch `try-fix-student-search`). Quando a busca foi reescrita para Eloquent (`LegacyStudentBuilder::findStudentWithMultipleSearch`), o filtro não foi reintroduzido. Hoje não há como filtrar a listagem de alunos por situação da matrícula.

## O que este PR faz

Reintroduz o select **"Situação"** na seção "Filtros de alunos", já na arquitetura atual (`StudentFilter` + `LegacyStudentBuilder`), reusando componentes existentes.

## Implementação

- `app/Models/DataSearch/StudentFilter.php`: novo parâmetro `enrollmentStatus`.
- `ieducar/intranet/educar_aluno_lst.php`: re-adiciona `inputsHelper()->dynamic('situacaoMatricula')` (reusa o helper `Portabilis_View_Helper_DynamicInput_SituacaoMatricula` e o enum `EnrollmentStatusFilter`); alimenta `enrollmentStatus` (vira `null` quando "Todas"/`ALL` → no-op).
- `app/Models/Builders/LegacyStudentBuilder.php`: o filtro `registration` passa a aceitar `status` e `whereRegistration()` filtra por `matricula.aprovado` via `whereHas('registrations', ...)`, mantendo `active()`:
  - "Exceto Transferidos/Deixou de Frequentar" (id 9) → `whereNotIn('aprovado', [RegistrationStatus::TRANSFERRED, RegistrationStatus::ABANDONED])`;
  - demais → `where('aprovado', $status)`.

## Por que não reintroduz o problema da remoção anterior

A remoção de 2022 estava ligada ao `INNER JOIN` com `relatorio.view_situacao`. Esta versão **não usa a view**: filtra direto em `matricula.aprovado` via `whereHas('registrations', ...)` (subconsulta `EXISTS`), sem multiplicar linhas. É o mesmo caminho que o projeto já adotou no commit `e1aab68bd` e que os scopes de `LegacyRegistrationBuilder` (`statusTransfer()`, `finalized()`) já usam. A `relatorio.view_situacao` opera no nível de matrícula_turma (join por `cod_matricula`/`cod_turma`/`sequencial`), inadequada para uma listagem por aluno.

## Como testar

1. Acesse a listagem de alunos (menu Alunos).
2. Em "Filtros de alunos", selecione uma **Situação** (ex.: Transferido) e busque.
3. Confira os resultados, situações como Transferido/Falecido (cujas matrículas permanecem `ativo = 1`) aparecem; "Todas" não aplica filtro; "Exceto Transferidos/Deixou de Frequentar" exclui as situações 4 e 6.