### PR TITLE
Implementa getProperty() no Registro50 do Educacenso

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ website/i18n/*
 ieducar/tests/log
 
 .opencode
+composer.phar
 
 programmatic-types.graphql
 schema-directives.graphql

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ website/i18n/*
 # this is the code coverage generated when running phpunit.
 ieducar/tests/log
 
+.opencode
+
 programmatic-types.graphql
 schema-directives.graphql
 _lighthouse_ide_helper.php

--- a/app/Models/Educacenso/Registro50.php
+++ b/app/Models/Educacenso/Registro50.php
@@ -3,6 +3,7 @@
 namespace App\Models\Educacenso;
 
 use iEducar\Modules\Educacenso\Model\OrganizacaoCurricular;
+use iEducar\Modules\Educacenso\Model\TipoItinerarioFormativo;
 use iEducar\Modules\Servidores\Model\FuncaoExercida;
 
 class Registro50 implements ItemOfRegistro30, RegistroEducacenso
@@ -183,7 +184,39 @@ class Registro50 implements ItemOfRegistro30, RegistroEducacenso
      */
     public function getProperty($column)
     {
-        // TODO: Implement getProperty() method.
+        if ($column >= 1 && $column <= 8) {
+            return $this->{[
+                1 => 'registro',
+                2 => 'inepEscola',
+                3 => 'codigoPessoa',
+                4 => 'inepDocente',
+                5 => 'codigoTurma',
+                6 => 'inepTurma',
+                7 => 'funcaoDocente',
+                8 => 'tipoVinculo',
+            ][$column]};
+        }
+
+        if ($column >= 9 && $column <= 33) {
+            return $this->componentes[$column - 9] ?? null;
+        }
+
+        if ($column >= 34 && $column <= 37) {
+            return $this->areaItinerario
+                ? (int) in_array([
+                    34 => TipoItinerarioFormativo::LINGUANGENS,
+                    35 => TipoItinerarioFormativo::MATEMATICA,
+                    36 => TipoItinerarioFormativo::CIENCIAS_NATUREZA,
+                    37 => TipoItinerarioFormativo::CIENCIAS_HUMANAS,
+                ][$column], (array) $this->areaItinerario)
+                : null;
+        }
+
+        if ($column === 38) {
+            return $this->lecionaItinerarioTecnicoProfissional;
+        }
+
+        return null;
     }
 
     public function organizacaoCurricularDescritivas()

--- a/tests/Educacenso/Model/Registro50GetPropertyTest.php
+++ b/tests/Educacenso/Model/Registro50GetPropertyTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Educacenso\Model;
+
+use App\Models\Educacenso\Registro50;
+use iEducar\Modules\Educacenso\Model\TipoItinerarioFormativo;
+use Tests\TestCase;
+
+class Registro50GetPropertyTest extends TestCase
+{
+    public function test_retorna_propriedades_diretas_das_colunas_1_a_8()
+    {
+        $registro = new Registro50;
+        $registro->registro = '50';
+        $registro->inepEscola = '12345';
+        $registro->codigoPessoa = '67890';
+        $registro->inepDocente = '11111';
+        $registro->codigoTurma = '22222';
+        $registro->inepTurma = '33333';
+        $registro->funcaoDocente = '1';
+        $registro->tipoVinculo = '2';
+
+        $this->assertSame('50', $registro->getProperty(1));
+        $this->assertSame('12345', $registro->getProperty(2));
+        $this->assertSame('67890', $registro->getProperty(3));
+        $this->assertSame('11111', $registro->getProperty(4));
+        $this->assertSame('22222', $registro->getProperty(5));
+        $this->assertSame('33333', $registro->getProperty(6));
+        $this->assertSame('1', $registro->getProperty(7));
+        $this->assertSame('2', $registro->getProperty(8));
+    }
+
+    public function test_retorna_componentes_das_colunas_9_a_33()
+    {
+        $registro = new Registro50;
+        $registro->componentes = range(0, 24);
+
+        $this->assertSame(0, $registro->getProperty(9));
+        $this->assertSame(12, $registro->getProperty(21));
+        $this->assertSame(24, $registro->getProperty(33));
+    }
+
+    public function test_retorna_null_para_componente_inexistente()
+    {
+        $registro = new Registro50;
+        $registro->componentes = [];
+
+        $this->assertNull($registro->getProperty(9));
+    }
+
+    public function test_retorna_area_itinerario_colunas_34_a_37()
+    {
+        $registro = new Registro50;
+        $registro->areaItinerario = [
+            TipoItinerarioFormativo::LINGUANGENS,
+            TipoItinerarioFormativo::CIENCIAS_HUMANAS,
+        ];
+
+        $this->assertSame(1, $registro->getProperty(34));
+        $this->assertSame(0, $registro->getProperty(35));
+        $this->assertSame(0, $registro->getProperty(36));
+        $this->assertSame(1, $registro->getProperty(37));
+    }
+
+    public function test_retorna_null_quando_area_itinerario_vazia()
+    {
+        $registro = new Registro50;
+        $registro->areaItinerario = null;
+
+        $this->assertNull($registro->getProperty(34));
+        $this->assertNull($registro->getProperty(35));
+        $this->assertNull($registro->getProperty(36));
+        $this->assertNull($registro->getProperty(37));
+    }
+
+    public function test_retorna_leciona_itinerario_tecnico_coluna_38()
+    {
+        $registro = new Registro50;
+        $registro->lecionaItinerarioTecnicoProfissional = 1;
+
+        $this->assertSame(1, $registro->getProperty(38));
+    }
+
+    public function test_retorna_null_para_coluna_nao_mapeada()
+    {
+        $registro = new Registro50;
+
+        $this->assertNull($registro->getProperty(0));
+        $this->assertNull($registro->getProperty(39));
+        $this->assertNull($registro->getProperty(999));
+    }
+}


### PR DESCRIPTION
Implementa o método `getProperty()` na classe `Registro50`, que retorna o valor correspondente à coluna no layout do Educacenso:

- Colunas 1 a 8: propriedades diretas do registro
- Colunas 9 a 33: componentes curriculares ($componentes)
- Colunas 34 a 37: áreas do itinerário formativo ($areaItinerario)
- Coluna 38: indicador de itinerário técnico profissional ($lecionaItinerarioTecnicoProfissional)
- Colunas não mapeadas: null

Resolves #1147